### PR TITLE
Add symbolic link creation service, WPF interface, and tests

### DIFF
--- a/src/MklinkUI.App/MainViewModel.cs
+++ b/src/MklinkUI.App/MainViewModel.cs
@@ -1,0 +1,155 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Windows.Forms;
+using System.Windows.Input;
+using MklinkUI.Core.Services;
+
+namespace MklinkUI.App;
+
+public class MainViewModel : INotifyPropertyChanged
+{
+    private readonly IDeveloperModeService _developerModeService;
+    private readonly ISymbolicLinkService _symbolicLinkService;
+    private readonly string _logPath;
+
+    public MainViewModel(IDeveloperModeService developerModeService, ISymbolicLinkService symbolicLinkService)
+    {
+        _developerModeService = developerModeService;
+        _symbolicLinkService = symbolicLinkService;
+        DeveloperModeStatus = _developerModeService.IsDeveloperModeEnabled()
+            ? "Developer Mode is enabled"
+            : "Developer Mode is disabled";
+
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        _logPath = Path.Combine(appData, "MklinkUI", "app.log");
+
+        BrowseSourceCommand = new RelayCommand(BrowseSource);
+        BrowseDestinationCommand = new RelayCommand(BrowseDestination);
+        CreateLinkCommand = new RelayCommand(CreateLink, CanCreateLink);
+        UpdateLogContent();
+    }
+
+    private string _sourcePath = string.Empty;
+    public string SourcePath
+    {
+        get => _sourcePath;
+        set
+        {
+            if (_sourcePath != value)
+            {
+                _sourcePath = value;
+                OnPropertyChanged();
+                RaiseCanExecuteChanged();
+            }
+        }
+    }
+
+    private string _destinationPath = string.Empty;
+    public string DestinationPath
+    {
+        get => _destinationPath;
+        set
+        {
+            if (_destinationPath != value)
+            {
+                _destinationPath = value;
+                OnPropertyChanged();
+                RaiseCanExecuteChanged();
+            }
+        }
+    }
+
+    private bool _isDirectory;
+    public bool IsDirectory
+    {
+        get => _isDirectory;
+        set
+        {
+            if (_isDirectory != value)
+            {
+                _isDirectory = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    public string DeveloperModeStatus { get; }
+
+    private string _logContent = string.Empty;
+    public string LogContent
+    {
+        get => _logContent;
+        private set
+        {
+            _logContent = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public ICommand BrowseSourceCommand { get; }
+    public ICommand BrowseDestinationCommand { get; }
+    public ICommand CreateLinkCommand { get; }
+
+    private void BrowseSource()
+    {
+        if (IsDirectory)
+        {
+            using var dialog = new FolderBrowserDialog();
+            if (dialog.ShowDialog() == DialogResult.OK)
+                SourcePath = dialog.SelectedPath;
+        }
+        else
+        {
+            var dialog = new Microsoft.Win32.OpenFileDialog();
+            if (dialog.ShowDialog() == true)
+                SourcePath = dialog.FileName;
+        }
+    }
+
+    private void BrowseDestination()
+    {
+        if (IsDirectory)
+        {
+            using var dialog = new FolderBrowserDialog();
+            if (dialog.ShowDialog() == DialogResult.OK)
+                DestinationPath = dialog.SelectedPath;
+        }
+        else
+        {
+            var dialog = new Microsoft.Win32.SaveFileDialog();
+            if (dialog.ShowDialog() == true)
+                DestinationPath = dialog.FileName;
+        }
+    }
+
+    private void CreateLink()
+    {
+        _symbolicLinkService.CreateSymbolicLink(SourcePath, DestinationPath, IsDirectory);
+        UpdateLogContent();
+    }
+
+    private bool CanCreateLink() => !string.IsNullOrWhiteSpace(SourcePath) && !string.IsNullOrWhiteSpace(DestinationPath);
+
+    private void UpdateLogContent()
+    {
+        if (File.Exists(_logPath))
+        {
+            var lines = File.ReadLines(_logPath).TakeLast(20);
+            LogContent = string.Join(Environment.NewLine, lines);
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+    private void RaiseCanExecuteChanged()
+    {
+        if (CreateLinkCommand is RelayCommand rc)
+            rc.RaiseCanExecuteChanged();
+    }
+}
+

--- a/src/MklinkUI.App/MainWindow.xaml
+++ b/src/MklinkUI.App/MainWindow.xaml
@@ -1,8 +1,34 @@
 <Window x:Class="MklinkUI.App.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Mklink UI" Height="200" Width="400">
-    <StackPanel Margin="10">
-        <TextBlock x:Name="DeveloperModeStatus" FontSize="16" />
-    </StackPanel>
+        Title="Mklink UI" Height="300" Width="600">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+
+        <TextBox Grid.Row="0" Grid.Column="0" Margin="0,0,5,5" Text="{Binding SourcePath, UpdateSourceTrigger=PropertyChanged}"/>
+        <Button Grid.Row="0" Grid.Column="1" Content="Browse" Margin="0,0,0,5" Command="{Binding BrowseSourceCommand}"/>
+
+        <TextBox Grid.Row="1" Grid.Column="0" Margin="0,0,5,5" Text="{Binding DestinationPath, UpdateSourceTrigger=PropertyChanged}"/>
+        <Button Grid.Row="1" Grid.Column="1" Content="Browse" Margin="0,0,0,5" Command="{Binding BrowseDestinationCommand}"/>
+
+        <CheckBox Grid.Row="2" Grid.ColumnSpan="2" Content="Directory Link" IsChecked="{Binding IsDirectory}" Margin="0,0,0,5"/>
+
+        <TextBlock Grid.Row="3" Grid.ColumnSpan="2" Text="{Binding DeveloperModeStatus}" Margin="0,0,0,5"/>
+
+        <Button Grid.Row="4" Grid.ColumnSpan="2" Content="Create Link" Command="{Binding CreateLinkCommand}" Margin="0,0,0,5"/>
+
+        <TextBox Grid.Row="5" Grid.ColumnSpan="2" Text="{Binding LogContent}" IsReadOnly="True" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto"/>
+    </Grid>
 </Window>
+

--- a/src/MklinkUI.App/MainWindow.xaml.cs
+++ b/src/MklinkUI.App/MainWindow.xaml.cs
@@ -5,15 +5,14 @@ namespace MklinkUI.App;
 
 public partial class MainWindow : Window
 {
-    private readonly IDeveloperModeService _developerModeService;
-
     public MainWindow()
     {
         InitializeComponent();
         var registry = new WindowsRegistry();
-        _developerModeService = new DeveloperModeService(registry);
-        DeveloperModeStatus.Text = _developerModeService.IsDeveloperModeEnabled()
-            ? "Developer Mode is enabled"
-            : "Developer Mode is disabled";
+        var developerModeService = new DeveloperModeService(registry);
+        var native = new WindowsSymbolicLink();
+        var linkService = new SymbolicLinkService(native);
+        DataContext = new MainViewModel(developerModeService, linkService);
     }
 }
+

--- a/src/MklinkUI.App/MklinkUI.App.csproj
+++ b/src/MklinkUI.App/MklinkUI.App.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
   <ItemGroup>

--- a/src/MklinkUI.App/RelayCommand.cs
+++ b/src/MklinkUI.App/RelayCommand.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Windows.Input;
+
+namespace MklinkUI.App;
+
+public class RelayCommand : ICommand
+{
+    private readonly Action _execute;
+    private readonly Func<bool>? _canExecute;
+
+    public RelayCommand(Action execute, Func<bool>? canExecute = null)
+    {
+        _execute = execute;
+        _canExecute = canExecute;
+    }
+
+    public bool CanExecute(object? parameter) => _canExecute?.Invoke() ?? true;
+
+    public void Execute(object? parameter) => _execute();
+
+    public event EventHandler? CanExecuteChanged;
+
+    public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}
+

--- a/src/MklinkUI.Core/MklinkUI.Core.csproj
+++ b/src/MklinkUI.Core/MklinkUI.Core.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="3.1.1" />
+  </ItemGroup>
+
 </Project>

--- a/src/MklinkUI.Core/Services/ISymbolicLink.cs
+++ b/src/MklinkUI.Core/Services/ISymbolicLink.cs
@@ -1,0 +1,7 @@
+namespace MklinkUI.Core.Services;
+
+public interface ISymbolicLink
+{
+    (bool Success, int ErrorCode) CreateSymbolicLink(string linkPath, string targetPath, bool isDirectory);
+}
+

--- a/src/MklinkUI.Core/Services/ISymbolicLinkService.cs
+++ b/src/MklinkUI.Core/Services/ISymbolicLinkService.cs
@@ -1,0 +1,7 @@
+namespace MklinkUI.Core.Services;
+
+public interface ISymbolicLinkService
+{
+    SymbolicLinkResult CreateSymbolicLink(string sourcePath, string destinationPath, bool isDirectory);
+}
+

--- a/src/MklinkUI.Core/Services/SymbolicLinkResult.cs
+++ b/src/MklinkUI.Core/Services/SymbolicLinkResult.cs
@@ -1,0 +1,4 @@
+namespace MklinkUI.Core.Services;
+
+public record SymbolicLinkResult(bool Success, string? ErrorMessage);
+

--- a/src/MklinkUI.Core/Services/SymbolicLinkService.cs
+++ b/src/MklinkUI.Core/Services/SymbolicLinkService.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel;
+using Serilog;
+
+namespace MklinkUI.Core.Services;
+
+public class SymbolicLinkService : ISymbolicLinkService
+{
+    private readonly ISymbolicLink _symbolicLink;
+
+    public SymbolicLinkService(ISymbolicLink symbolicLink)
+    {
+        _symbolicLink = symbolicLink;
+    }
+
+    public SymbolicLinkResult CreateSymbolicLink(string sourcePath, string destinationPath, bool isDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(sourcePath) || string.IsNullOrWhiteSpace(destinationPath))
+        {
+            const string message = "Source and destination paths must be provided.";
+            Log.Error(message);
+            return new SymbolicLinkResult(false, message);
+        }
+
+        try
+        {
+            var (success, error) = _symbolicLink.CreateSymbolicLink(destinationPath, sourcePath, isDirectory);
+            if (success)
+            {
+                Log.Information("Created {Type} symbolic link: {Dest} -> {Source}", isDirectory ? "directory" : "file", destinationPath, sourcePath);
+                return new SymbolicLinkResult(true, null);
+            }
+
+            var errorMessage = new Win32Exception(error).Message;
+            Log.Error("Failed to create symbolic link {Dest} -> {Source}: {ErrorMessage}", destinationPath, sourcePath, errorMessage);
+            return new SymbolicLinkResult(false, errorMessage);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Exception while creating symbolic link {Dest} -> {Source}", destinationPath, sourcePath);
+            return new SymbolicLinkResult(false, ex.Message);
+        }
+    }
+}
+

--- a/src/MklinkUI.Core/Services/WindowsSymbolicLink.cs
+++ b/src/MklinkUI.Core/Services/WindowsSymbolicLink.cs
@@ -1,0 +1,24 @@
+using System.Runtime.InteropServices;
+
+namespace MklinkUI.Core.Services;
+
+public class WindowsSymbolicLink : ISymbolicLink
+{
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern bool CreateSymbolicLink(string lpSymlinkFileName, string lpTargetFileName, SymbolicLinkFlag dwFlags);
+
+    public (bool Success, int ErrorCode) CreateSymbolicLink(string linkPath, string targetPath, bool isDirectory)
+    {
+        var flags = isDirectory ? SymbolicLinkFlag.Directory : SymbolicLinkFlag.File;
+        var result = CreateSymbolicLink(linkPath, targetPath, flags);
+        var error = result ? 0 : Marshal.GetLastWin32Error();
+        return (result, error);
+    }
+
+    private enum SymbolicLinkFlag : uint
+    {
+        File = 0,
+        Directory = 1
+    }
+}
+

--- a/src/MklinkUI.Tests/SymbolicLinkServiceTests.cs
+++ b/src/MklinkUI.Tests/SymbolicLinkServiceTests.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel;
+using FluentAssertions;
+using Moq;
+using MklinkUI.Core.Services;
+
+namespace MklinkUI.Tests;
+
+public class SymbolicLinkServiceTests
+{
+    [Fact]
+    public void CreateSymbolicLink_ReturnsSuccess_WhenNativeSucceeds()
+    {
+        var native = new Mock<ISymbolicLink>();
+        native.Setup(n => n.CreateSymbolicLink(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+            .Returns((true, 0));
+        var service = new SymbolicLinkService(native.Object);
+
+        var result = service.CreateSymbolicLink("source", "dest", false);
+
+        result.Success.Should().BeTrue();
+        result.ErrorMessage.Should().BeNull();
+    }
+
+    [Fact]
+    public void CreateSymbolicLink_ReturnsError_WhenNativeFails()
+    {
+        var native = new Mock<ISymbolicLink>();
+        native.Setup(n => n.CreateSymbolicLink(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+            .Returns((false, 5));
+        var service = new SymbolicLinkService(native.Object);
+
+        var result = service.CreateSymbolicLink("source", "dest", false);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Be(new Win32Exception(5).Message);
+    }
+
+    [Fact]
+    public void CreateSymbolicLink_ReturnsError_WhenPathsMissing()
+    {
+        var native = new Mock<ISymbolicLink>();
+        var service = new SymbolicLinkService(native.Object);
+
+        var result = service.CreateSymbolicLink("", "", false);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Be("Source and destination paths must be provided.");
+    }
+}
+


### PR DESCRIPTION
## Summary
- Implement service for creating file and directory symbolic links using Windows `CreateSymbolicLink` with Serilog logging
- Add MVVM-based WPF interface for browsing source/destination, toggling link type, and viewing logs & Developer Mode status
- Introduce unit tests covering success, failure, and invalid path scenarios

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689182f5dfc48326bd0ac611fb085781