### PR TITLE
Add theming, tray icon, and drag-drop support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,15 @@ MklinkUI is a small utility for Windows 11 that creates symbolic links and displ
    dotnet test src/MklinkUI.Tests/MklinkUI.Tests.csproj
    ```
 
-Logs are written to `%AppData%/MklinkUI/app.log`.
+Logs are written to `%AppData%/MklinkUI/app.log`. User settings are stored in `%AppData%/MklinkUI/settings.json`.
 
 ## Usage
-The application displays the current Developer Mode status. Symlink creation and installer features will be added in future iterations.
+The application displays the current Developer Mode status. You can create file or directory symbolic links, browse paths, or drag files directly onto the input boxes.
+
+### UI Features
+- **Theme toggle** – switch between light, dark, or match the system. Changes apply immediately and persist between sessions.
+- **Tray icon** – minimizing or closing hides the window to the system tray. The tray menu provides *Open* and *Exit* actions, and an option allows starting minimized.
+- **Drag and drop** – drop files or folders onto the source or destination boxes to populate the paths.
+- **Browse buttons** – open standard Windows dialogs to select source files/folders and destination targets.
+
+Symlink creation and installer features will be added in future iterations.

--- a/src/MklinkUI.App/App.xaml
+++ b/src/MklinkUI.App/App.xaml
@@ -3,5 +3,12 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
+        <Style TargetType="Window">
+            <Setter Property="Background" Value="{DynamicResource AppBackground}"/>
+            <Setter Property="Foreground" Value="{DynamicResource AppForeground}"/>
+        </Style>
+        <Style TargetType="Control">
+            <Setter Property="Foreground" Value="{DynamicResource AppForeground}"/>
+        </Style>
     </Application.Resources>
 </Application>

--- a/src/MklinkUI.App/MainWindow.xaml
+++ b/src/MklinkUI.App/MainWindow.xaml
@@ -9,6 +9,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -17,11 +18,15 @@
             <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
 
-        <TextBox Grid.Row="0" Grid.Column="0" Margin="0,0,5,5" Text="{Binding SourcePath, UpdateSourceTrigger=PropertyChanged}"/>
-        <Button Grid.Row="0" Grid.Column="1" Content="Browse" Margin="0,0,0,5" Command="{Binding BrowseSourceCommand}"/>
+        <TextBox Grid.Row="0" Grid.Column="0" Margin="0,0,5,5"
+                 Text="{Binding SourcePath, UpdateSourceTrigger=PropertyChanged}"
+                 AllowDrop="True" PreviewDragOver="PathBox_PreviewDragOver" Drop="SourceBox_Drop"/>
+        <Button Grid.Row="0" Grid.Column="1" Content="Browse..." Margin="0,0,0,5" Command="{Binding BrowseSourceCommand}"/>
 
-        <TextBox Grid.Row="1" Grid.Column="0" Margin="0,0,5,5" Text="{Binding DestinationPath, UpdateSourceTrigger=PropertyChanged}"/>
-        <Button Grid.Row="1" Grid.Column="1" Content="Browse" Margin="0,0,0,5" Command="{Binding BrowseDestinationCommand}"/>
+        <TextBox Grid.Row="1" Grid.Column="0" Margin="0,0,5,5"
+                 Text="{Binding DestinationPath, UpdateSourceTrigger=PropertyChanged}"
+                 AllowDrop="True" PreviewDragOver="PathBox_PreviewDragOver" Drop="DestinationBox_Drop"/>
+        <Button Grid.Row="1" Grid.Column="1" Content="Browse..." Margin="0,0,0,5" Command="{Binding BrowseDestinationCommand}"/>
 
         <CheckBox Grid.Row="2" Grid.ColumnSpan="2" Content="Directory Link" IsChecked="{Binding IsDirectory}" Margin="0,0,0,5"/>
 
@@ -31,14 +36,19 @@
         </StackPanel>
 
         <StackPanel Grid.Row="4" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="0,0,0,5" HorizontalAlignment="Left">
+            <TextBlock Text="Theme:" VerticalAlignment="Center" Margin="0,0,5,0"/>
+            <ComboBox Width="120" ItemsSource="{Binding Themes}" SelectedItem="{Binding SelectedTheme}" />
+            <CheckBox Content="Start minimized to tray" IsChecked="{Binding StartMinimizedToTray}" Margin="10,0,0,0"/>
+        </StackPanel>
+
+        <StackPanel Grid.Row="5" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="0,0,0,5" HorizontalAlignment="Left">
             <Button Content="Create Link" Command="{Binding CreateLinkCommand}" Margin="0,0,5,0"/>
             <Button Content="Open Logs" Command="{Binding OpenLogCommand}" Margin="0,0,5,0"/>
             <Button Content="Run as Admin" Command="{Binding RelaunchElevatedCommand}"/>
         </StackPanel>
 
-        <TextBox Grid.Row="5" Grid.ColumnSpan="2" Text="{Binding LogContent}" IsReadOnly="True" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto"/>
+        <TextBox Grid.Row="6" Grid.ColumnSpan="2" Text="{Binding LogContent}" IsReadOnly="True" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto"/>
 
-        <TextBlock Grid.Row="6" Grid.ColumnSpan="2" Text="{Binding StatusMessage}" Foreground="Red" Margin="0,5,0,0"/>
+        <TextBlock Grid.Row="7" Grid.ColumnSpan="2" Text="{Binding StatusMessage}" Foreground="Red" Margin="0,5,0,0"/>
     </Grid>
 </Window>
-

--- a/src/MklinkUI.App/MainWindow.xaml.cs
+++ b/src/MklinkUI.App/MainWindow.xaml.cs
@@ -1,18 +1,103 @@
+using System;
+using System.ComponentModel;
+using System.IO;
 using System.Windows;
+using Forms = System.Windows.Forms;
 using MklinkUI.Core.Services;
+using MklinkUI.Core.Settings;
+using Application = System.Windows.Application;
 
 namespace MklinkUI.App;
 
 public partial class MainWindow : Window
 {
+    private readonly Forms.NotifyIcon _notifyIcon;
+    private readonly MainViewModel _viewModel;
+
     public MainWindow()
     {
         InitializeComponent();
         var registry = new WindowsRegistry();
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        var settingsPath = Path.Combine(appData, "MklinkUI", "settings.json");
+        var settingsService = new SettingsService(settingsPath);
+        var themeService = new ThemeService(registry);
+        var themeManager = new ThemeManager();
+
         var developerModeService = new DeveloperModeService(registry);
         var native = new WindowsSymbolicLink();
         var linkService = new SymbolicLinkService(native);
-        DataContext = new MainViewModel(developerModeService, linkService);
+        _viewModel = new MainViewModel(developerModeService, linkService, settingsService, themeService, themeManager);
+        DataContext = _viewModel;
+
+        _notifyIcon = new Forms.NotifyIcon
+        {
+            Icon = System.Drawing.SystemIcons.Application,
+            Visible = false,
+            Text = "MklinkUI"
+        };
+        _notifyIcon.DoubleClick += (_, _) => ShowMainWindow();
+        var menu = new Forms.ContextMenuStrip();
+        menu.Items.Add("Open", null, (_, _) => ShowMainWindow());
+        menu.Items.Add("Exit", null, (_, _) => { _notifyIcon.Visible = false; Application.Current.Shutdown(); });
+        _notifyIcon.ContextMenuStrip = menu;
+
+        StateChanged += MainWindow_StateChanged;
+        Closing += MainWindow_Closing;
+        Loaded += MainWindow_Loaded;
+    }
+
+    private void MainWindow_Loaded(object sender, RoutedEventArgs e)
+    {
+        if (_viewModel.StartMinimizedToTray)
+            HideWindowToTray();
+    }
+
+    private void MainWindow_StateChanged(object? sender, EventArgs e)
+    {
+        if (WindowState == WindowState.Minimized)
+            HideWindowToTray();
+    }
+
+    private void MainWindow_Closing(object? sender, CancelEventArgs e)
+    {
+        e.Cancel = true;
+        HideWindowToTray();
+    }
+
+    private void HideWindowToTray()
+    {
+        Hide();
+        _notifyIcon.Visible = true;
+    }
+
+    private void ShowMainWindow()
+    {
+        Show();
+        WindowState = WindowState.Normal;
+        Activate();
+        _notifyIcon.Visible = false;
+    }
+
+    private void PathBox_PreviewDragOver(object sender, System.Windows.DragEventArgs e)
+    {
+        e.Handled = true;
+        e.Effects = e.Data.GetDataPresent(System.Windows.DataFormats.FileDrop)
+            ? System.Windows.DragDropEffects.Copy
+            : System.Windows.DragDropEffects.None;
+    }
+
+    private void SourceBox_Drop(object sender, System.Windows.DragEventArgs e)
+        => HandleDrop(e, p => _viewModel.SourcePath = p);
+
+    private void DestinationBox_Drop(object sender, System.Windows.DragEventArgs e)
+        => HandleDrop(e, p => _viewModel.DestinationPath = p);
+
+    private void HandleDrop(System.Windows.DragEventArgs e, Action<string> setPath)
+    {
+        if (e.Data.GetData(System.Windows.DataFormats.FileDrop) is string[] files && files.Length == 1)
+            setPath(files[0]);
+        else
+            _viewModel.StatusMessage = "Invalid drop target.";
     }
 }
-

--- a/src/MklinkUI.App/ThemeManager.cs
+++ b/src/MklinkUI.App/ThemeManager.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Windows;
+using MklinkUI.Core.Settings;
+
+namespace MklinkUI.App;
+
+public class ThemeManager
+{
+    private readonly ResourceDictionary _light = new() { Source = new Uri("Themes/Light.xaml", UriKind.Relative) };
+    private readonly ResourceDictionary _dark = new() { Source = new Uri("Themes/Dark.xaml", UriKind.Relative) };
+
+    public void Apply(ThemeOption theme)
+    {
+        var app = Application.Current;
+        if (app == null) return;
+        var dictionaries = app.Resources.MergedDictionaries;
+        dictionaries.Remove(_light);
+        dictionaries.Remove(_dark);
+        dictionaries.Add(theme == ThemeOption.Dark ? _dark : _light);
+    }
+}

--- a/src/MklinkUI.App/Themes/Dark.xaml
+++ b/src/MklinkUI.App/Themes/Dark.xaml
@@ -1,0 +1,5 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <SolidColorBrush x:Key="AppBackground" Color="#FF1E1E1E"/>
+    <SolidColorBrush x:Key="AppForeground" Color="White"/>
+</ResourceDictionary>

--- a/src/MklinkUI.App/Themes/Light.xaml
+++ b/src/MklinkUI.App/Themes/Light.xaml
@@ -1,0 +1,5 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <SolidColorBrush x:Key="AppBackground" Color="White"/>
+    <SolidColorBrush x:Key="AppForeground" Color="Black"/>
+</ResourceDictionary>

--- a/src/MklinkUI.Core/Settings/AppSettings.cs
+++ b/src/MklinkUI.Core/Settings/AppSettings.cs
@@ -1,0 +1,7 @@
+namespace MklinkUI.Core.Settings;
+
+public class AppSettings
+{
+    public ThemeOption Theme { get; set; } = ThemeOption.System;
+    public bool StartMinimizedToTray { get; set; }
+}

--- a/src/MklinkUI.Core/Settings/ISettingsService.cs
+++ b/src/MklinkUI.Core/Settings/ISettingsService.cs
@@ -1,0 +1,7 @@
+namespace MklinkUI.Core.Settings;
+
+public interface ISettingsService
+{
+    AppSettings Load();
+    void Save(AppSettings settings);
+}

--- a/src/MklinkUI.Core/Settings/IThemeService.cs
+++ b/src/MklinkUI.Core/Settings/IThemeService.cs
@@ -1,0 +1,7 @@
+namespace MklinkUI.Core.Settings;
+
+public interface IThemeService
+{
+    ThemeOption GetSystemTheme();
+    ThemeOption ResolveTheme(ThemeOption preference);
+}

--- a/src/MklinkUI.Core/Settings/SettingsService.cs
+++ b/src/MklinkUI.Core/Settings/SettingsService.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using System.Text.Json;
+
+namespace MklinkUI.Core.Settings;
+
+public class SettingsService : ISettingsService
+{
+    private readonly string _path;
+
+    public SettingsService(string path)
+    {
+        _path = path;
+    }
+
+    public AppSettings Load()
+    {
+        if (!File.Exists(_path))
+            return new AppSettings();
+        try
+        {
+            var json = File.ReadAllText(_path);
+            return JsonSerializer.Deserialize<AppSettings>(json) ?? new AppSettings();
+        }
+        catch
+        {
+            return new AppSettings();
+        }
+    }
+
+    public void Save(AppSettings settings)
+    {
+        var dir = Path.GetDirectoryName(_path);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+        var json = JsonSerializer.Serialize(settings);
+        File.WriteAllText(_path, json);
+    }
+}

--- a/src/MklinkUI.Core/Settings/ThemeOption.cs
+++ b/src/MklinkUI.Core/Settings/ThemeOption.cs
@@ -1,0 +1,8 @@
+namespace MklinkUI.Core.Settings;
+
+public enum ThemeOption
+{
+    System,
+    Light,
+    Dark
+}

--- a/src/MklinkUI.Core/Settings/ThemeService.cs
+++ b/src/MklinkUI.Core/Settings/ThemeService.cs
@@ -1,0 +1,24 @@
+using MklinkUI.Core.Services;
+
+namespace MklinkUI.Core.Settings;
+
+public class ThemeService : IThemeService
+{
+    private readonly IRegistry _registry;
+    private const string Key = @"HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
+    private const string Value = "AppsUseLightTheme";
+
+    public ThemeService(IRegistry registry)
+    {
+        _registry = registry;
+    }
+
+    public ThemeOption GetSystemTheme()
+    {
+        var val = _registry.GetValue(Key, Value, 1);
+        return val is int i && i == 0 ? ThemeOption.Dark : ThemeOption.Light;
+    }
+
+    public ThemeOption ResolveTheme(ThemeOption preference)
+        => preference == ThemeOption.System ? GetSystemTheme() : preference;
+}

--- a/src/MklinkUI.Tests/MainViewModelTests.cs
+++ b/src/MklinkUI.Tests/MainViewModelTests.cs
@@ -4,17 +4,27 @@ using FluentAssertions;
 using Moq;
 using MklinkUI.App;
 using MklinkUI.Core.Services;
+using MklinkUI.Core.Settings;
 
 namespace MklinkUI.Tests;
 
 public class MainViewModelTests
 {
+    private static MainViewModel CreateViewModel(Mock<IDeveloperModeService>? dev = null, Mock<ISymbolicLinkService>? link = null)
+    {
+        dev ??= new Mock<IDeveloperModeService>();
+        link ??= new Mock<ISymbolicLinkService>();
+        var settings = new Mock<ISettingsService>();
+        settings.Setup(s => s.Load()).Returns(new AppSettings());
+        var theme = new Mock<IThemeService>();
+        theme.Setup(t => t.ResolveTheme(It.IsAny<ThemeOption>())).Returns(ThemeOption.Light);
+        return new MainViewModel(dev.Object, link.Object, settings.Object, theme.Object, new ThemeManager());
+    }
+
     [Fact]
     public void CreateLinkCommand_Disabled_WhenPathsInvalid()
     {
-        var dev = new Mock<IDeveloperModeService>();
-        var link = new Mock<ISymbolicLinkService>();
-        var vm = new MainViewModel(dev.Object, link.Object);
+        var vm = CreateViewModel();
 
         vm.SourcePath = "relative";
         vm.DestinationPath = "relative";
@@ -25,11 +35,10 @@ public class MainViewModelTests
     [Fact]
     public void StatusMessage_ShowsError_WhenCreationFails()
     {
-        var dev = new Mock<IDeveloperModeService>();
         var link = new Mock<ISymbolicLinkService>();
         link.Setup(s => s.CreateSymbolicLink(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
             .Returns(new SymbolicLinkResult(false, "error", 0));
-        var vm = new MainViewModel(dev.Object, link.Object);
+        var vm = CreateViewModel(link: link);
 
         vm.SourcePath = Path.GetFullPath("/tmp/a.txt");
         File.WriteAllText(vm.SourcePath, "a");

--- a/src/MklinkUI.Tests/SettingsServiceTests.cs
+++ b/src/MklinkUI.Tests/SettingsServiceTests.cs
@@ -1,0 +1,29 @@
+using System.IO;
+using FluentAssertions;
+using MklinkUI.Core.Settings;
+using Xunit;
+
+namespace MklinkUI.Tests;
+
+public class SettingsServiceTests
+{
+    [Fact]
+    public void SaveAndLoad_PersistsSettings()
+    {
+        var temp = Path.GetTempFileName();
+        try
+        {
+            var service = new SettingsService(temp);
+            var settings = new AppSettings { Theme = ThemeOption.Dark, StartMinimizedToTray = true };
+            service.Save(settings);
+
+            var loaded = service.Load();
+            loaded.Theme.Should().Be(ThemeOption.Dark);
+            loaded.StartMinimizedToTray.Should().BeTrue();
+        }
+        finally
+        {
+            File.Delete(temp);
+        }
+    }
+}

--- a/src/MklinkUI.Tests/ThemeServiceTests.cs
+++ b/src/MklinkUI.Tests/ThemeServiceTests.cs
@@ -1,0 +1,31 @@
+using FluentAssertions;
+using Moq;
+using MklinkUI.Core.Settings;
+using MklinkUI.Core.Services;
+using Xunit;
+
+namespace MklinkUI.Tests;
+
+public class ThemeServiceTests
+{
+    [Theory]
+    [InlineData(1, ThemeOption.Light)]
+    [InlineData(0, ThemeOption.Dark)]
+    public void GetSystemTheme_UsesRegistryValue(int registryValue, ThemeOption expected)
+    {
+        var registry = new Mock<IRegistry>();
+        registry.Setup(r => r.GetValue(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<object?>()))
+            .Returns(registryValue);
+        var service = new ThemeService(registry.Object);
+
+        service.GetSystemTheme().Should().Be(expected);
+    }
+
+    [Fact]
+    public void ResolveTheme_ReturnsPreference_WhenNotSystem()
+    {
+        var registry = new Mock<IRegistry>();
+        var service = new ThemeService(registry.Object);
+        service.ResolveTheme(ThemeOption.Dark).Should().Be(ThemeOption.Dark);
+    }
+}


### PR DESCRIPTION
## Summary
- add light/dark/system theming with persisted user preference
- integrate system tray icon with start-minimized option
- enable drag/drop and browse buttons for path selection

## Testing
- `dotnet test src/MklinkUI.Tests/MklinkUI.Tests.csproj --framework net8.0`


------
https://chatgpt.com/codex/tasks/task_e_68918d1a2ecc83268be16607f9b42493