### PR TITLE
Add themed control styles and tests

### DIFF
--- a/src/MklinkUI.App/Themes/Dark.xaml
+++ b/src/MklinkUI.App/Themes/Dark.xaml
@@ -2,4 +2,24 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <SolidColorBrush x:Key="AppBackground" Color="#FF1E1E1E"/>
     <SolidColorBrush x:Key="AppForeground" Color="White"/>
+    <SolidColorBrush x:Key="ControlBackground" Color="#FF2D2D30"/>
+    <SolidColorBrush x:Key="ControlBorder" Color="#FF3E3E42"/>
+
+    <Style TargetType="Button">
+        <Setter Property="Background" Value="{StaticResource ControlBackground}"/>
+        <Setter Property="Foreground" Value="{DynamicResource AppForeground}"/>
+        <Setter Property="BorderBrush" Value="{StaticResource ControlBorder}"/>
+    </Style>
+
+    <Style TargetType="TextBox">
+        <Setter Property="Background" Value="{StaticResource ControlBackground}"/>
+        <Setter Property="Foreground" Value="{DynamicResource AppForeground}"/>
+        <Setter Property="BorderBrush" Value="{StaticResource ControlBorder}"/>
+    </Style>
+
+    <Style TargetType="ComboBox">
+        <Setter Property="Background" Value="{StaticResource ControlBackground}"/>
+        <Setter Property="Foreground" Value="{DynamicResource AppForeground}"/>
+        <Setter Property="BorderBrush" Value="{StaticResource ControlBorder}"/>
+    </Style>
 </ResourceDictionary>

--- a/src/MklinkUI.App/Themes/Light.xaml
+++ b/src/MklinkUI.App/Themes/Light.xaml
@@ -2,4 +2,24 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <SolidColorBrush x:Key="AppBackground" Color="White"/>
     <SolidColorBrush x:Key="AppForeground" Color="Black"/>
+    <SolidColorBrush x:Key="ControlBackground" Color="#FFF0F0F0"/>
+    <SolidColorBrush x:Key="ControlBorder" Color="#FFCCCCCC"/>
+
+    <Style TargetType="Button">
+        <Setter Property="Background" Value="{StaticResource ControlBackground}"/>
+        <Setter Property="Foreground" Value="{DynamicResource AppForeground}"/>
+        <Setter Property="BorderBrush" Value="{StaticResource ControlBorder}"/>
+    </Style>
+
+    <Style TargetType="TextBox">
+        <Setter Property="Background" Value="White"/>
+        <Setter Property="Foreground" Value="{DynamicResource AppForeground}"/>
+        <Setter Property="BorderBrush" Value="{StaticResource ControlBorder}"/>
+    </Style>
+
+    <Style TargetType="ComboBox">
+        <Setter Property="Background" Value="White"/>
+        <Setter Property="Foreground" Value="{DynamicResource AppForeground}"/>
+        <Setter Property="BorderBrush" Value="{StaticResource ControlBorder}"/>
+    </Style>
 </ResourceDictionary>

--- a/src/MklinkUI.Tests/ThemeResourceTests.cs
+++ b/src/MklinkUI.Tests/ThemeResourceTests.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Xunit;
+
+namespace MklinkUI.Tests;
+
+public class ThemeResourceTests
+{
+    [Theory]
+    [InlineData("Light.xaml")]
+    [InlineData("Dark.xaml")]
+    public void Theme_contains_control_styles(string themeFile)
+    {
+        var basePath = AppContext.BaseDirectory;
+        var themePath = Path.GetFullPath(Path.Combine(basePath, "..", "..", "..", "..", "MklinkUI.App", "Themes", themeFile));
+        var doc = XDocument.Load(themePath);
+        var styles = doc.Root?.Elements().Where(e => e.Name.LocalName == "Style").ToList();
+
+        Assert.NotNull(styles);
+        Assert.Contains(styles, e => e.Attribute("TargetType")?.Value.Contains("Button") == true);
+        Assert.Contains(styles, e => e.Attribute("TargetType")?.Value.Contains("TextBox") == true);
+        Assert.Contains(styles, e => e.Attribute("TargetType")?.Value.Contains("ComboBox") == true);
+    }
+}
+


### PR DESCRIPTION
## Summary
- style buttons, text boxes, and combo boxes for light and dark themes
- add test ensuring each theme dictionary defines control styles

## Testing
- `dotnet test src/MklinkUI.Tests/MklinkUI.Tests.csproj -f net8.0`


------
https://chatgpt.com/codex/tasks/task_e_68919320b48c8326979041ebae521aa4