### PR TITLE
Add developer mode tools and refresh command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,6 @@ The application displays the current Developer Mode status. You can create file 
 - **Tray icon** – minimizing or closing hides the window to the system tray. The tray menu provides *Open* and *Exit* actions, and an option allows starting minimized.
 - **Drag and drop** – drop files or folders onto the source or destination boxes to populate the paths.
 - **Browse buttons** – open standard Windows dialogs to select source files/folders and destination targets.
+- **Developer Mode tools** – open Windows Developer Mode settings or refresh the detected Developer Mode status.
 
 Symlink creation and installer features will be added in future iterations.

--- a/src/MklinkUI.App/MainViewModel.cs
+++ b/src/MklinkUI.App/MainViewModel.cs
@@ -49,6 +49,8 @@ public class MainViewModel : INotifyPropertyChanged
         CreateLinkCommand = new RelayCommand(CreateLink, CanCreateLink);
         OpenLogCommand = new RelayCommand(OpenLogFolder);
         RelaunchElevatedCommand = new RelayCommand(RelaunchElevated, () => !_isElevated);
+        OpenDeveloperModeSettingsCommand = new RelayCommand(OpenDeveloperModeSettings);
+        RefreshDeveloperModeCommand = new RelayCommand(RefreshDeveloperMode);
 
         Themes = Enum.GetValues<ThemeOption>();
         var settings = _settingsService.Load();
@@ -138,7 +140,16 @@ public class MainViewModel : INotifyPropertyChanged
         }
     }
 
-    public string DeveloperModeStatus { get; }
+    private string _developerModeStatus = string.Empty;
+    public string DeveloperModeStatus
+    {
+        get => _developerModeStatus;
+        private set
+        {
+            _developerModeStatus = value;
+            OnPropertyChanged();
+        }
+    }
 
     public string ElevationStatus { get; }
 
@@ -169,6 +180,8 @@ public class MainViewModel : INotifyPropertyChanged
     public ICommand CreateLinkCommand { get; }
     public ICommand OpenLogCommand { get; }
     public ICommand RelaunchElevatedCommand { get; }
+    public ICommand OpenDeveloperModeSettingsCommand { get; }
+    public ICommand RefreshDeveloperModeCommand { get; }
 
     private void ApplyAndSaveTheme()
     {
@@ -305,6 +318,30 @@ public class MainViewModel : INotifyPropertyChanged
         {
             StatusMessage = "Elevation cancelled.";
         }
+    }
+
+    private void OpenDeveloperModeSettings()
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = "ms-settings:developers",
+                UseShellExecute = true
+            });
+        }
+        catch
+        {
+            StatusMessage = "Failed to open settings.";
+        }
+    }
+
+    private void RefreshDeveloperMode()
+    {
+        _developerModeService.RefreshState();
+        DeveloperModeStatus = _developerModeService.IsDeveloperModeEnabled()
+            ? "Developer Mode is enabled"
+            : "Developer Mode is disabled";
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/src/MklinkUI.App/MainWindow.xaml
+++ b/src/MklinkUI.App/MainWindow.xaml
@@ -33,6 +33,8 @@
         <StackPanel Grid.Row="3" Grid.ColumnSpan="2" Orientation="Vertical" Margin="0,0,0,5">
             <TextBlock Text="{Binding DeveloperModeStatus}"/>
             <TextBlock Text="{Binding ElevationStatus}"/>
+            <Button Content="Open Developer Mode settings" Command="{Binding OpenDeveloperModeSettingsCommand}" Margin="0,5,0,0"/>
+            <Button Content="Refresh Developer Mode" Command="{Binding RefreshDeveloperModeCommand}" Margin="0,5,0,0"/>
         </StackPanel>
 
         <StackPanel Grid.Row="4" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="0,0,0,5" HorizontalAlignment="Left">

--- a/src/MklinkUI.Core/Services/DeveloperModeService.cs
+++ b/src/MklinkUI.Core/Services/DeveloperModeService.cs
@@ -5,15 +5,19 @@ public class DeveloperModeService : IDeveloperModeService
     private readonly IRegistry _registry;
     private const string KeyPath = @"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock";
     private const string ValueName = "AllowDevelopmentWithoutDevLicense";
+    private bool _isDeveloperModeEnabled;
 
     public DeveloperModeService(IRegistry registry)
     {
         _registry = registry;
+        RefreshState();
     }
 
-    public bool IsDeveloperModeEnabled()
+    public bool IsDeveloperModeEnabled() => _isDeveloperModeEnabled;
+
+    public void RefreshState()
     {
         var value = _registry.GetValue(KeyPath, ValueName, 0);
-        return value is int intValue && intValue == 1;
+        _isDeveloperModeEnabled = value is int intValue && intValue == 1;
     }
 }

--- a/src/MklinkUI.Core/Services/IDeveloperModeService.cs
+++ b/src/MklinkUI.Core/Services/IDeveloperModeService.cs
@@ -3,4 +3,5 @@ namespace MklinkUI.Core.Services;
 public interface IDeveloperModeService
 {
     bool IsDeveloperModeEnabled();
+    void RefreshState();
 }

--- a/src/MklinkUI.Tests/DeveloperModeServiceTests.cs
+++ b/src/MklinkUI.Tests/DeveloperModeServiceTests.cs
@@ -22,4 +22,20 @@ public class DeveloperModeServiceTests
         // Assert
         result.Should().BeTrue();
     }
+
+    [Fact]
+    public void RefreshState_RechecksRegistry()
+    {
+        var registry = new Mock<IRegistry>();
+        registry.SetupSequence(r => r.GetValue(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<object?>()))
+            .Returns(0)
+            .Returns(1);
+        var service = new DeveloperModeService(registry.Object);
+
+        service.IsDeveloperModeEnabled().Should().BeFalse();
+
+        service.RefreshState();
+
+        service.IsDeveloperModeEnabled().Should().BeTrue();
+    }
 }

--- a/src/MklinkUI.Tests/MainViewModelTests.cs
+++ b/src/MklinkUI.Tests/MainViewModelTests.cs
@@ -48,5 +48,18 @@ public class MainViewModelTests
 
         vm.StatusMessage.Should().Be("error");
     }
+
+    [Fact]
+    public void RefreshDeveloperModeCommand_UpdatesStatus()
+    {
+        var dev = new Mock<IDeveloperModeService>();
+        dev.SetupSequence(d => d.IsDeveloperModeEnabled()).Returns(false).Returns(true);
+        var vm = CreateViewModel(dev);
+
+        vm.RefreshDeveloperModeCommand.Execute(null);
+
+        dev.Verify(d => d.RefreshState(), Times.Once);
+        vm.DeveloperModeStatus.Should().Be("Developer Mode is enabled");
+    }
 }
 #endif


### PR DESCRIPTION
## Summary
- add commands to open Developer Mode settings and refresh its state
- expose DeveloperModeService.RefreshState for rechecking registry
- cover refresh logic in unit tests and document the new buttons

## Testing
- `dotnet test src/MklinkUI.Tests/MklinkUI.Tests.csproj -f net8.0`


------
https://chatgpt.com/codex/tasks/task_e_6891943946f88326af8f46621b2dd5f5