### PR TITLE
Prompt for elevation or developer mode on privilege errors

### DIFF
--- a/src/MklinkUI.App/MainViewModel.cs
+++ b/src/MklinkUI.App/MainViewModel.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Security.Principal;
 using System.Windows.Forms;
 using System.Windows.Input;
+using System.Windows;
 using MklinkUI.Core.Services;
 using MklinkUI.Core.Settings;
 
@@ -36,13 +37,15 @@ public class MainViewModel : INotifyPropertyChanged
 
         DeveloperModeStatus = _developerModeService.IsDeveloperModeEnabled()
             ? "Developer Mode is enabled"
-            : "Developer Mode is disabled";
+            : "Developer Mode is disabled (enables symbolic link creation without administrator rights)";
 
         var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
         _logPath = Path.Combine(appData, "MklinkUI", "app.log");
 
         _isElevated = new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator);
-        ElevationStatus = _isElevated ? "Running as Administrator" : "Not running as Administrator";
+        ElevationStatus = _isElevated
+            ? "Running as Administrator"
+            : "Not running as Administrator (required unless Developer Mode is enabled)";
 
         BrowseSourceCommand = new RelayCommand(BrowseSource);
         BrowseDestinationCommand = new RelayCommand(BrowseDestination);
@@ -225,14 +228,60 @@ public class MainViewModel : INotifyPropertyChanged
         }
 
         var result = _symbolicLinkService.CreateSymbolicLink(SourcePath, DestinationPath, IsDirectory);
-        StatusMessage = result.Success
-            ? "Symbolic link created successfully."
-            : result.ErrorMessage ?? "Failed to create symbolic link.";
+        if (result.Success)
+        {
+            StatusMessage = "Symbolic link created successfully.";
+            UpdateLogContent();
+            return;
+        }
 
-        if (!result.Success && result.ErrorCode == 1314 && !_isElevated)
-            StatusMessage += " Try running as administrator.";
+        if (result.ErrorCode == 1314)
+            HandlePrivilegeError();
+        else
+            StatusMessage = result.ErrorMessage ?? "Failed to create symbolic link.";
 
         UpdateLogContent();
+    }
+
+    private void HandlePrivilegeError()
+    {
+        var devModeEnabled = _developerModeService.IsDeveloperModeEnabled();
+        StatusMessage = devModeEnabled
+            ? "Administrator privileges are required to create this symbolic link."
+            : "Developer Mode is disabled and administrator privileges are required to create this symbolic link.";
+
+        if (_isElevated)
+            return;
+
+        if (!devModeEnabled)
+        {
+            var openSettings = MessageBox.Show(
+                "Developer Mode is disabled. Enable it in Windows Settings to create symbolic links without administrator privileges. Open Developer Mode settings now?",
+                "Developer Mode disabled", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+
+            if (openSettings == MessageBoxResult.Yes)
+            {
+                try
+                {
+                    Process.Start(new ProcessStartInfo
+                    {
+                        FileName = "ms-settings:developers",
+                        UseShellExecute = true
+                    });
+                }
+                catch
+                {
+                    // ignored
+                }
+            }
+        }
+
+        var relaunch = MessageBox.Show(
+            "Would you like to relaunch the application with administrative rights?",
+            "Elevation required", MessageBoxButton.YesNo, MessageBoxImage.Question);
+
+        if (relaunch == MessageBoxResult.Yes && RelaunchElevatedCommand.CanExecute(null))
+            RelaunchElevatedCommand.Execute(null);
     }
 
     private bool CanCreateLink() => ValidateInput().IsValid;


### PR DESCRIPTION
## Summary
- Clarify Developer Mode and elevation status messages.
- Detect privilege error when creating links and prompt to enable Developer Mode or relaunch elevated.

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*
- `dotnet test --framework net8.0`


------
https://chatgpt.com/codex/tasks/task_e_68919315fcfc8326a9b1b942ed7d1ad4