### PR TITLE
Resolve cross-platform build issues

### DIFF
--- a/src/MklinkUI.App/MainViewModel.cs
+++ b/src/MklinkUI.App/MainViewModel.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Security.Principal;
-using System.Windows.Forms;
+using Forms = System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows;
 using MklinkUI.Core.Services;
@@ -203,8 +203,8 @@ public class MainViewModel : INotifyPropertyChanged
     {
         if (IsDirectory)
         {
-            using var dialog = new FolderBrowserDialog();
-            if (dialog.ShowDialog() == DialogResult.OK)
+            using var dialog = new Forms.FolderBrowserDialog();
+            if (dialog.ShowDialog() == Forms.DialogResult.OK)
                 SourcePath = dialog.SelectedPath;
         }
         else
@@ -219,8 +219,8 @@ public class MainViewModel : INotifyPropertyChanged
     {
         if (IsDirectory)
         {
-            using var dialog = new FolderBrowserDialog();
-            if (dialog.ShowDialog() == DialogResult.OK)
+            using var dialog = new Forms.FolderBrowserDialog();
+            if (dialog.ShowDialog() == Forms.DialogResult.OK)
                 DestinationPath = dialog.SelectedPath;
         }
         else

--- a/src/MklinkUI.Core/Services/WindowsRegistry.cs
+++ b/src/MklinkUI.Core/Services/WindowsRegistry.cs
@@ -1,7 +1,12 @@
 using Microsoft.Win32;
+using System.Runtime.Versioning;
 
 namespace MklinkUI.Core.Services;
 
+/// <summary>
+/// Windows-specific implementation of <see cref="IRegistry"/>.
+/// </summary>
+[SupportedOSPlatform("windows")]
 public class WindowsRegistry : IRegistry
 {
     public object? GetValue(string keyName, string valueName, object? defaultValue)

--- a/src/MklinkUI.Core/Services/WindowsSymbolicLink.cs
+++ b/src/MklinkUI.Core/Services/WindowsSymbolicLink.cs
@@ -1,7 +1,12 @@
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace MklinkUI.Core.Services;
 
+/// <summary>
+/// Windows-specific symbolic link implementation using kernel32 APIs.
+/// </summary>
+[SupportedOSPlatform("windows")]
 public class WindowsSymbolicLink : ISymbolicLink
 {
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]


### PR DESCRIPTION
## Summary
- Fix ambiguous `MessageBox` references by aliasing Windows Forms and updating folder dialog calls.
- Mark Windows-only registry and symbolic link services with `SupportedOSPlatform("windows")` attributes.

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet test --framework net8.0`


------
https://chatgpt.com/codex/tasks/task_e_6891a6a9e5248326a26b61c59edfb633