### PR TITLE
Add WiX installer project

### DIFF
--- a/MklinkUI.sln
+++ b/MklinkUI.sln
@@ -10,6 +10,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MklinkUI.Core", "src\Mklink
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MklinkUI.Tests", "src\MklinkUI.Tests\MklinkUI.Tests.csproj", "{6B9803E7-8348-44D8-A2AE-FAE02038998A}"
 EndProject
+Project("{B7DD6F7E-DEF8-4E67-B5B7-07EF123DB6F0}") = "MklinkUI.Installer", "installer\\MklinkUI.Installer.wixproj", "{E6C90857-DCD7-4B67-85E2-0ECE7743917C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,10 +28,14 @@ Global
 		{E3A3C6AD-7DA9-4911-A83B-5DFE0A35E4EC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6B9803E7-8348-44D8-A2AE-FAE02038998A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6B9803E7-8348-44D8-A2AE-FAE02038998A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6B9803E7-8348-44D8-A2AE-FAE02038998A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6B9803E7-8348-44D8-A2AE-FAE02038998A}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
+                {6B9803E7-8348-44D8-A2AE-FAE02038998A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {6B9803E7-8348-44D8-A2AE-FAE02038998A}.Release|Any CPU.Build.0 = Release|Any CPU
+                {E6C90857-DCD7-4B67-85E2-0ECE7743917C}.Debug|Any CPU.ActiveCfg = Debug|x64
+                {E6C90857-DCD7-4B67-85E2-0ECE7743917C}.Debug|Any CPU.Build.0 = Debug|x64
+                {E6C90857-DCD7-4B67-85E2-0ECE7743917C}.Release|Any CPU.ActiveCfg = Release|x64
+                {E6C90857-DCD7-4B67-85E2-0ECE7743917C}.Release|Any CPU.Build.0 = Release|x64
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/installer/MklinkUI.Installer.wixproj
+++ b/installer/MklinkUI.Installer.wixproj
@@ -1,3 +1,21 @@
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- WiX installer project -->
+<Project Sdk="WixToolset.Sdk/6.0.0">
+  <PropertyGroup>
+    <OutputType>Package</OutputType>
+    <TargetPlatform>win64</TargetPlatform>
+    <WixOutputPath>bin\$(Configuration)\$(Platform)\</WixOutputPath>
+  </PropertyGroup>
+
+  <!-- Publish the application before building the installer -->
+  <Target Name="PublishApp" BeforeTargets="Build">
+    <Exec Command="dotnet publish ..\src\MklinkUI.App\MklinkUI.App.csproj -c $(Configuration) -r win-x64 -p:PublishProfile=FolderProfile" />
+  </Target>
+
+  <ItemGroup>
+    <PackageReference Include="WixToolset.UI.wixext" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\MklinkUI.App\MklinkUI.App.csproj" />
+  </ItemGroup>
 </Project>
+

--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -1,15 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-  <Product Id="*" Name="MklinkUI" Language="1033" Version="1.0.0.0" Manufacturer="MklinkUI" UpgradeCode="12345678-1234-1234-1234-123456789abc">
-    <Package InstallerVersion="500" Compressed="yes" InstallScope="perMachine" />
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+  <Package Name="MklinkUI"
+           Manufacturer="MklinkUI"
+           Version="1.0.0.0"
+           UpgradeCode="12345678-1234-1234-1234-123456789abc"
+           Scope="perMachine"
+           InstallerVersion="500"
+           Compressed="yes">
+
     <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
-    <MediaTemplate />
-    <Icon Id="AppIcon" SourceFile="..\\assets\\icons\\mklinkUI_icon.ico" />
-    <Property Id="ARPPRODUCTICON" Value="AppIcon" />
+
     <Feature Id="MainFeature" Title="MklinkUI" Level="1">
       <ComponentGroupRef Id="ProductComponents" />
     </Feature>
-  </Product>
+
+    <ui:WixUI Id="WixUI_Minimal" InstallDirectory="INSTALLFOLDER" />
+
+    <Icon Id="AppIcon" SourceFile="..\\assets\\icons\\mklinkUI_icon.ico" />
+    <Property Id="ARPPRODUCTICON" Value="AppIcon" />
+  </Package>
 
   <Fragment>
     <Directory Id="TARGETDIR" Name="SourceDir">
@@ -22,10 +31,11 @@
 
   <Fragment>
     <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
-      <Component Id="ExeComponent" Guid="*">
-        <File Source="..\src\MklinkUI.App\bin\$(var.Configuration)\net8.0-windows\MklinkUI.App.exe" KeyPath="yes" />
+      <Component Guid="*">
+        <File Source="..\\src\\MklinkUI.App\\bin\\$(var.Configuration)\\net8.0-windows\\win-x64\\publish\\win-x64\\MklinkUI.App.exe" KeyPath="yes" />
         <Shortcut Id="StartMenuShortcut" Directory="ProgramMenuFolder" Name="MklinkUI" WorkingDirectory="INSTALLFOLDER" Icon="AppIcon" Advertise="no" />
       </Component>
     </ComponentGroup>
   </Fragment>
 </Wix>
+


### PR DESCRIPTION
## Summary
- add WixToolset-based installer project that publishes MklinkUI.App and builds an MSI
- include installer project in the solution with x64 configuration mappings

## Testing
- `dotnet build MklinkUI.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_689431ec62a4832687bbb24e1c0bb3f3