### PR TITLE
fix: reference built-in directories

### DIFF
--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -21,12 +21,12 @@
   </Package>
 
   <Fragment>
-    <Directory Id="TARGETDIR" Name="SourceDir">
+    <DirectoryRef Id="TARGETDIR">
       <Directory Id="ProgramFilesFolder">
         <Directory Id="INSTALLFOLDER" Name="MklinkUI" />
       </Directory>
-      <Directory Id="ProgramMenuFolder" />
-    </Directory>
+    </DirectoryRef>
+    <DirectoryRef Id="ProgramMenuFolder" />
   </Fragment>
 
   <Fragment>


### PR DESCRIPTION
## Summary
- reference built-in TARGETDIR instead of redefining it to avoid conflicts with WiX virtual symbol
- reference built-in ProgramMenuFolder rather than defining it to eliminate conflict with WiX virtual symbol

## Testing
- `dotnet workload install windowsdesktop` *(fails: Workload ID windowsdesktop is not recognized)*
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_689437f09b5083268a4e82124846bf6d