### PR TITLE
Fix non-advertised shortcut key path

### DIFF
--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -32,7 +32,13 @@
   <Fragment>
     <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
       <Component Guid="*">
-        <File Source="..\\src\\MklinkUI.App\\bin\\$(var.Configuration)\\net8.0-windows\\publish\\MklinkUI.App.exe" KeyPath="yes" />
+        <File Source="..\\src\\MklinkUI.App\\bin\\$(var.Configuration)\\net8.0-windows\\publish\\MklinkUI.App.exe" />
+        <RegistryValue Root="HKCU"
+                       Key="Software\\MklinkUI"
+                       Name="Installed"
+                       Type="string"
+                       Value="1"
+                       KeyPath="yes" />
         <Shortcut Id="StartMenuShortcut" Directory="ProgramMenuFolder" Name="MklinkUI" WorkingDirectory="INSTALLFOLDER" Icon="AppIcon" Advertise="no" />
       </Component>
     </ComponentGroup>


### PR DESCRIPTION
## Summary
- use registry key as component KeyPath for non-advertised shortcut to avoid ICE43

## Testing
- `dotnet build installer/MklinkUI.Installer.wixproj` *(fails: wix.exe : warning WIX0000: The WiX Toolset only supports Windows)*
- `dotnet test` *(fails: Microsoft.WindowsDesktop.App 8.0.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68943fabeb3083268187162e4096fc53