### PR TITLE
Fix installer component GUID usage and update directory elements

### DIFF
--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -21,25 +21,30 @@
   </Package>
 
   <Fragment>
-    <DirectoryRef Id="TARGETDIR">
-      <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="MklinkUI" />
-      </Directory>
-    </DirectoryRef>
-    <DirectoryRef Id="ProgramMenuFolder" />
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MklinkUI" />
+    </StandardDirectory>
+    <StandardDirectory Id="ProgramMenuFolder" />
   </Fragment>
 
   <Fragment>
     <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
       <Component Guid="*">
-        <File Source="..\\src\\MklinkUI.App\\bin\\$(var.Configuration)\\net8.0-windows\\publish\\MklinkUI.App.exe" />
+        <File Source="..\\src\\MklinkUI.App\\bin\\$(var.Configuration)\\net8.0-windows\\publish\\MklinkUI.App.exe" KeyPath="yes" />
+        <Shortcut Id="StartMenuShortcut"
+                  Directory="ProgramMenuFolder"
+                  Name="MklinkUI"
+                  WorkingDirectory="INSTALLFOLDER"
+                  Icon="AppIcon"
+                  Advertise="no" />
+      </Component>
+      <Component Guid="*">
         <RegistryValue Root="HKCU"
                        Key="Software\\MklinkUI"
                        Name="Installed"
                        Type="string"
                        Value="1"
                        KeyPath="yes" />
-        <Shortcut Id="StartMenuShortcut" Directory="ProgramMenuFolder" Name="MklinkUI" WorkingDirectory="INSTALLFOLDER" Icon="AppIcon" Advertise="no" />
       </Component>
     </ComponentGroup>
   </Fragment>


### PR DESCRIPTION
## Summary
- split file and registry entries into separate components so auto GUIDs are valid
- replace deprecated DirectoryRef usage with StandardDirectory elements

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: Invalid response from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6894424003e88326b4ec14d6f44642eb