### PR TITLE
Fix application startup

### DIFF
--- a/src/MklinkUI.App/App.xaml.cs
+++ b/src/MklinkUI.App/App.xaml.cs
@@ -17,6 +17,8 @@ public partial class App : Application
             .CreateLogger();
 
         Log.Information("Application starting");
+
+        InitializeComponent();
     }
 
     protected override void OnExit(ExitEventArgs e)


### PR DESCRIPTION
## Summary
- load XAML resources during startup so the main window is shown

## Testing
- `dotnet test` *(fails: You must install or update .NET to run this application. App: /workspace/mklinkUI/src/MklinkUI.Tests/bin/Debug/net8.0-windows/testhost.dll)*


------
https://chatgpt.com/codex/tasks/task_e_689458cf16948326a0dfd3db1971d7b2