### PR TITLE
Fix binding for log content

### DIFF
--- a/src/MklinkUI.App/MainViewModel.cs
+++ b/src/MklinkUI.App/MainViewModel.cs
@@ -1,0 +1,17 @@
+using System;
+using System.IO;
+
+namespace MklinkUI.App;
+
+public class MainViewModel
+{
+    public string LogContent { get; }
+
+    public MainViewModel()
+    {
+        // Load the log file content if it exists; otherwise empty string.
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        var logFile = Path.Combine(appData, "MklinkUI", "app.log");
+        LogContent = File.Exists(logFile) ? File.ReadAllText(logFile) : string.Empty;
+    }
+}

--- a/src/MklinkUI.App/MainWindow.xaml
+++ b/src/MklinkUI.App/MainWindow.xaml
@@ -1,8 +1,17 @@
 <Window x:Class="MklinkUI.App.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:MklinkUI.App"
         Title="Mklink UI" Height="200" Width="400">
+    <Window.DataContext>
+        <local:MainViewModel />
+    </Window.DataContext>
+
     <StackPanel Margin="10">
         <TextBlock x:Name="DeveloperModeStatus" FontSize="16" />
+        <!-- Display the log file content. The TextBox binding is marked OneWay because
+             LogContent is a read-only property and a TwoWay binding would cause a runtime
+             exception. -->
+        <TextBox Text="{Binding LogContent, Mode=OneWay}" IsReadOnly="True" Margin="0,10,0,0" />
     </StackPanel>
 </Window>


### PR DESCRIPTION
## Summary
- Load log file content through a new `MainViewModel`
- Bind log text box in `MainWindow.xaml` with `Mode=OneWay` to avoid runtime error when using the read-only property

## Testing
- `dotnet test src/MklinkUI.Tests/MklinkUI.Tests.csproj -v minimal`
- `dotnet build -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894984d3fd08326912610e68ad0b305