### PR TITLE
Add Windows-only symlink support and Moq-based tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,27 @@
 # MklinkUI
 
-MklinkUI is a small utility for Windows 11 that creates symbolic links and displays whether Developer Mode is enabled.
+MklinkUI is a small web-based utility that reports whether Windows Developer Mode is enabled and creates file or directory symbolic links.
 
-## Projects
- - `MklinkUI.App`: WPF application for creating file and directory symbolic links with a tray icon.
- - `MklinkUI.Core`: Core logic and services.
- - `MklinkUI.Tests`: xUnit tests using FluentAssertions and Moq.
- - `installer`: WiX installer project for packaging the app.
+## Project Layout
+- `src/MklinlUi.Core` – core abstractions and the `SymlinkManager` coordinator.
+- `src/MklinlUi.Windows` – Windows-only services that read the registry and invoke the `CreateSymbolicLink` Win32 API.
+- `src/MklinlUi.Fakes` – fallback services used on non-Windows platforms.
+- `src/MklinlUi.WebUI` – ASP.NET Core front end that loads platform services at runtime.
+- `tests/MklinlUi.Tests` – xUnit tests using FluentAssertions and Moq.
 
-## Prerequisites
-- Windows 11
-- [.NET 8 SDK](https://dotnet.microsoft.com/)
-- Administrative rights or Developer Mode enabled
+## Running
+Restore dependencies and run the web app:
+```bash
+dotnet restore
+dotnet run --project src/MklinlUi.WebUI
+```
 
-## Setup
-1. Restore and build the solution:
-   ```powershell
-   dotnet restore
-   dotnet build
-   ```
-2. Run tests:
-   ```powershell
-   dotnet test src/MklinkUI.Tests/MklinkUI.Tests.csproj
-   ```
-3. Build the installer (requires [WiX Toolset 4](https://wixtoolset.org/)):
-   ```powershell
-   dotnet build installer/MklinkUI.Installer.wixproj
-   wix build installer/MklinkUI.Installer.wixproj -o MklinkUI.msi
-   ```
+## Publishing
+Publish the app for Windows:
+```bash
+dotnet publish src/MklinlUi.WebUI -c Release -r win-x64 --self-contained false
+```
+The published files are in `src/MklinlUi.WebUI/bin/Release/net8.0/publish`.
 
-## Logs and Settings
-Logs are written to `%AppData%/MklinkUI/app.log`.
-User settings are stored in `%AppData%/MklinkUI/settings.json`.
-
-## Usage
-The application displays the current Developer Mode status and can create file or directory symbolic links. Minimize or close the window to hide it in the system tray; the tray icon menu lets you reopen the app, exit, or start minimized. Browse paths or drag files directly onto the input boxes, then click **Create** to generate a link.
-
-### UI Features
-- **Theme toggle** – switch between light, dark, or match the system. Changes apply immediately and persist between sessions.
-- **Tray icon** – minimizing or closing hides the window to the system tray. The tray menu provides *Open* and *Exit* actions, and an option allows starting minimized.
-- **Drag and drop** – drop files or folders onto the source or destination boxes to populate the paths.
-- **Browse buttons** – open standard Windows dialogs to select source files/folders and destination targets.
+## Platform-specific behavior
+`ServiceRegistration.AddPlatformServices` loads `MklinlUi.Windows.dll` only when running on Windows. That assembly checks Developer Mode via the registry and creates links with P/Invoke. On other platforms the app falls back to the no-op implementations in `MklinlUi.Fakes.dll` so the site and tests can run without Windows-specific features.

--- a/src/MklinlUi.WebUI/MklinlUi.WebUI.csproj
+++ b/src/MklinlUi.WebUI/MklinlUi.WebUI.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\MklinlUi.Core\MklinlUi.Core.csproj" />
     <ProjectReference Include="..\MklinlUi.Fakes\MklinlUi.Fakes.csproj" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\MklinlUi.Windows\MklinlUi.Windows.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\MklinlUi.Windows\MklinlUi.Windows.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
 
   <ItemGroup>
@@ -17,7 +17,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Always</CopyToPublishDirectory>
     </Content>
-    <Content Include="..\MklinlUi.Windows\bin\$(Configuration)\net8.0\MklinlUi.Windows.dll">
+    <Content Include="..\MklinlUi.Windows\bin\$(Configuration)\net8.0-windows\MklinlUi.Windows.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Always</CopyToPublishDirectory>
     </Content>

--- a/src/MklinlUi.Windows/MklinlUi.Windows.csproj
+++ b/src/MklinlUi.Windows/MklinlUi.Windows.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/tests/MklinlUi.Tests/MklinlUi.Tests.csproj
+++ b/tests/MklinlUi.Tests/MklinlUi.Tests.csproj
@@ -22,6 +22,5 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/MklinlUi.Core/MklinlUi.Core.csproj" />
-    <ProjectReference Include="../../src/MklinlUi.Fakes/MklinlUi.Fakes.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- target `MklinlUi.Windows` for `net8.0-windows` and use P/Invoke to call `CreateSymbolicLink`
- copy the Windows assembly from `net8.0-windows` and skip target framework checks when building WebUI
- switch unit tests to Moq-based services and document final project layout

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689586725fdc8326ab589ff71c256770