### PR TITLE
feat: modern dark theme

### DIFF
--- a/src/MklinlUi.WebUI/Pages/Index.cshtml
+++ b/src/MklinlUi.WebUI/Pages/Index.cshtml
@@ -4,42 +4,47 @@
     ViewData["Title"] = "Symlink Creator";
 }
 
-<h2 class="mb-4">Symlink Creator</h2>
+<div class="card mb-4">
+    <div class="card-header">
+        <h2 class="m-0"><i class="fa-solid fa-link"></i> Symlink Creator</h2>
+    </div>
+    <div class="card-body">
+        <div class="mb-3">
+            <label class="form-label">Developer Mode:</label>
+            <span class="fw-bold @(Model.DeveloperModeEnabled ? "text-success" : "text-danger")">
+                @(Model.DeveloperModeEnabled ? "Enabled" : "Disabled")
+            </span>
+        </div>
 
-<div class="mb-3">
-    <label class="form-label">Developer Mode:</label>
-    <span class="fw-bold @(Model.DeveloperModeEnabled ? "text-success" : "text-danger")">
-        @(Model.DeveloperModeEnabled ? "Enabled" : "Disabled")
-    </span>
+        <form method="post">
+            <div class="mb-3">
+                <label class="form-label" asp-for="SourcePath">Source Path</label>
+                <div class="input-group">
+                    <input class="form-control" id="sourcePath" asp-for="SourcePath" />
+                    <button type="button" class="btn btn-outline-secondary" onclick="browseFile('sourcePath')"><i class="fa-solid fa-file me-1"></i>Browse</button>
+                </div>
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label" asp-for="DestinationPath">Destination Path</label>
+                <div class="input-group">
+                    <input class="form-control" id="destPath" asp-for="DestinationPath" />
+                    <button type="button" class="btn btn-outline-secondary" onclick="browseFolder('destPath')"><i class="fa-solid fa-folder-open me-1"></i>Browse</button>
+                </div>
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label" asp-for="LinkType">Symlink Type</label>
+                <select class="form-select" asp-for="LinkType">
+                    <option value="File">File</option>
+                    <option value="Folder">Folder</option>
+                </select>
+            </div>
+
+            <button type="submit" class="btn btn-primary"><i class="fa-solid fa-play me-1"></i>Create Symlink</button>
+        </form>
+    </div>
 </div>
-
-<form method="post">
-    <div class="mb-3">
-        <label class="form-label" asp-for="SourcePath">Source Path</label>
-        <div class="input-group">
-            <input class="form-control" id="sourcePath" asp-for="SourcePath" />
-            <button type="button" class="btn btn-outline-secondary" onclick="browseFile('sourcePath')">Browse</button>
-        </div>
-    </div>
-
-    <div class="mb-3">
-        <label class="form-label" asp-for="DestinationPath">Destination Path</label>
-        <div class="input-group">
-            <input class="form-control" id="destPath" asp-for="DestinationPath" />
-            <button type="button" class="btn btn-outline-secondary" onclick="browseFolder('destPath')">Browse</button>
-        </div>
-    </div>
-
-    <div class="mb-3">
-        <label class="form-label" asp-for="LinkType">Symlink Type</label>
-        <select class="form-select" asp-for="LinkType">
-            <option value="File">File</option>
-            <option value="Folder">Folder</option>
-        </select>
-    </div>
-
-    <button type="submit" class="btn btn-primary">Create Symlink</button>
-</form>
 
 @if (Model.Success.HasValue)
 {

--- a/src/MklinlUi.WebUI/Pages/Shared/_Layout.cshtml
+++ b/src/MklinlUi.WebUI/Pages/Shared/_Layout.cshtml
@@ -4,13 +4,14 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - MklinlUi.WebUI</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.3/dist/darkly/bootstrap.min.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/MklinlUi.WebUI.styles.css" asp-append-version="true" />
 </head>
 <body>
     <header>
-        <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
+        <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-dark bg-dark border-bottom box-shadow mb-3">
             <div class="container">
                 <a class="navbar-brand" asp-area="" asp-page="/Index">MklinlUi.WebUI</a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
@@ -20,19 +21,12 @@
                 <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
                     <ul class="navbar-nav flex-grow-1">
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-page="/Index">Home</a>
+                            <a class="nav-link" asp-area="" asp-page="/Index"><i class="fa-solid fa-house"></i> Home</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-page="/Privacy">Privacy</a>
+                            <a class="nav-link" asp-area="" asp-page="/Privacy"><i class="fa-solid fa-user-shield"></i> Privacy</a>
                         </li>
                     </ul>
-                    <div class="d-flex">
-                        <select id="theme-select" class="form-select form-select-sm" aria-label="Theme">
-                            <option value="system">System</option>
-                            <option value="light">Light</option>
-                            <option value="dark">Dark</option>
-                        </select>
-                    </div>
                 </div>
             </div>
         </nav>
@@ -43,7 +37,7 @@
         </main>
     </div>
 
-    <footer class="border-top footer text-muted">
+    <footer class="border-top footer bg-dark text-light">
         <div class="container">
             &copy; 2025 - MklinlUi.WebUI - <a asp-area="" asp-page="/Privacy">Privacy</a>
         </div>

--- a/src/MklinlUi.WebUI/Pages/Shared/_Layout.cshtml.css
+++ b/src/MklinlUi.WebUI/Pages/Shared/_Layout.cshtml.css
@@ -1,6 +1,7 @@
 ﻿/* Please see documentation at https://learn.microsoft.com/aspnet/core/client-side/bundling-and-minification
 for details on configuring this project to bundle and minify static web assets. */
 
+/* Dark theme overrides */
 a.navbar-brand {
   white-space: normal;
   text-align: center;
@@ -8,35 +9,18 @@ a.navbar-brand {
 }
 
 a {
-  color: #0077cc;
-}
-
-.btn-primary {
-  color: #fff;
-  background-color: #1b6ec2;
-  border-color: #1861ac;
-}
-
-.nav-pills .nav-link.active, .nav-pills .show > .nav-link {
-  color: #fff;
-  background-color: #1b6ec2;
-  border-color: #1861ac;
+  color: #9ecbff;
 }
 
 .border-top {
-  border-top: 1px solid #e5e5e5;
+  border-top: 1px solid #444;
 }
 .border-bottom {
-  border-bottom: 1px solid #e5e5e5;
+  border-bottom: 1px solid #444;
 }
 
 .box-shadow {
-  box-shadow: 0 .25rem .75rem rgba(0, 0, 0, .05);
-}
-
-button.accept-policy {
-  font-size: 1rem;
-  line-height: inherit;
+  box-shadow: 0 .25rem .75rem rgba(0, 0, 0, .5);
 }
 
 .footer {

--- a/src/MklinlUi.WebUI/wwwroot/css/site.css
+++ b/src/MklinlUi.WebUI/wwwroot/css/site.css
@@ -19,14 +19,6 @@ html {
 
 body {
   margin-bottom: 60px;
-}
-
-body[data-theme="dark"] {
   background-color: #121212;
   color: #f5f5f5;
-}
-
-body[data-theme="light"] {
-  background-color: #ffffff;
-  color: #212529;
 }

--- a/src/MklinlUi.WebUI/wwwroot/js/site.js
+++ b/src/MklinlUi.WebUI/wwwroot/js/site.js
@@ -1,26 +1,3 @@
-// Theme toggle
-(function () {
-    const select = document.getElementById('theme-select');
-    if (!select) return;
-
-    const setTheme = (theme) => {
-        if (theme === 'system') {
-            document.body.removeAttribute('data-theme');
-        } else {
-            document.body.setAttribute('data-theme', theme);
-        }
-        localStorage.setItem('theme', theme);
-    };
-
-    const stored = localStorage.getItem('theme') || 'system';
-    select.value = stored;
-    setTheme(stored);
-
-    select.addEventListener('change', (e) => {
-        setTheme(e.target.value);
-    });
-})();
-
 // File and folder browsers
 async function browseFile(inputId) {
     if (window.showOpenFilePicker) {


### PR DESCRIPTION
## Summary
- adopt Bootswatch Darkly and Font Awesome for a single, professional dark theme
- streamline layout and styling, removing theme toggle and reorganising form into a card
- clean up custom scripts and styles for simplified dark-mode-only UI

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68958f68924c832695d810b1fb210d2f