### PR TITLE
Implement missing symlink method and remove Serilog dependency

### DIFF
--- a/src/MklinlUi.WebUI/ServiceRegistration.cs
+++ b/src/MklinlUi.WebUI/ServiceRegistration.cs
@@ -80,6 +80,44 @@ public static class ServiceRegistration
                 return Task.FromResult(new SymlinkResult(false, ex.Message));
             }
         }
+
+        public Task<IReadOnlyList<SymlinkResult>> CreateFileSymlinksAsync(IEnumerable<string> sourceFiles,
+            string destinationFolder, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(sourceFiles);
+            ArgumentException.ThrowIfNullOrWhiteSpace(destinationFolder);
+
+            var results = new List<SymlinkResult>();
+
+            foreach (var source in sourceFiles)
+            {
+                if (string.IsNullOrWhiteSpace(source))
+                {
+                    results.Add(new SymlinkResult(false, "Invalid source."));
+                    continue;
+                }
+
+                var link = Path.Combine(destinationFolder, Path.GetFileName(source));
+
+                if (File.Exists(link) || Directory.Exists(link))
+                {
+                    results.Add(new SymlinkResult(false, "Link already exists."));
+                    continue;
+                }
+
+                try
+                {
+                    File.CreateSymbolicLink(link, source);
+                    results.Add(new SymlinkResult(true));
+                }
+                catch (Exception ex)
+                {
+                    results.Add(new SymlinkResult(false, ex.Message));
+                }
+            }
+
+            return Task.FromResult((IReadOnlyList<SymlinkResult>)results);
+        }
     }
 }
 

--- a/src/MklinlUi.Windows/SymlinkService.cs
+++ b/src/MklinlUi.Windows/SymlinkService.cs
@@ -1,5 +1,4 @@
 using MklinlUi.Core;
-using Serilog;
 
 namespace MklinlUi.Windows;
 
@@ -49,7 +48,6 @@ public sealed class SymlinkService : ISymlinkService
 
             if (File.Exists(link) || Directory.Exists(link))
             {
-                Log.Warning("Link already exists for {Link}", link);
                 results.Add(new SymlinkResult(false, "Link already exists."));
                 continue;
             }
@@ -57,12 +55,10 @@ public sealed class SymlinkService : ISymlinkService
             try
             {
                 File.CreateSymbolicLink(link, source);
-                Log.Information("Created link {Link} -> {Target}", link, source);
                 results.Add(new SymlinkResult(true));
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Failed to create link {Link}", link);
                 results.Add(new SymlinkResult(false, ex.Message));
             }
         }


### PR DESCRIPTION
## Summary
- implement `CreateFileSymlinksAsync` in default symlink service so it fulfills `ISymlinkService`
- remove Serilog dependency and associated logging from Windows `SymlinkService`

## Testing
- `dotnet restore`
- `dotnet build src/MklinlUi.Fakes`
- `dotnet build src/MklinlUi.WebUI`
- `dotnet build src/MklinlUi.Windows -p:EnableWindowsTargeting=true`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68986dfdb5e08326b4ab07844024420f