### PR TITLE
Fix cross-platform file symlink test

### DIFF
--- a/tests/MklinlUi.Tests/FileBatchSymlinkTests.cs
+++ b/tests/MklinlUi.Tests/FileBatchSymlinkTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using MklinlUi.Core;
 using MklinlUi.Fakes;
+using System.IO;
 using Xunit;
 
 namespace MklinlUi.Tests;
@@ -13,13 +14,14 @@ public class FileBatchSymlinkTests
         var service = new FakeSymlinkService();
         var manager = new SymlinkManager(new FakeDeveloperModeService(), service);
 
-        var sources = new[] { "/src/a.txt", "/src/b.txt" };
-        var results = await manager.CreateFileSymlinksAsync(sources, "/dest");
+        var dest = "/dest";
+        var sources = new[] { Path.Combine("/src", "a.txt"), Path.Combine("/src", "b.txt") };
+        var results = await manager.CreateFileSymlinksAsync(sources, dest);
 
         results.Should().HaveCount(2);
         results.Should().OnlyContain(r => r.Success);
-        service.Created.Should().Contain(("/dest/a.txt", "/src/a.txt"));
-        service.Created.Should().Contain(("/dest/b.txt", "/src/b.txt"));
+        service.Created.Should().Contain((Path.Combine(dest, "a.txt"), sources[0]));
+        service.Created.Should().Contain((Path.Combine(dest, "b.txt"), sources[1]));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- make file symlink creation test platform-independent by using Path.Combine

## Testing
- `dotnet restore`
- `dotnet build src/MklinlUi.Fakes`
- `dotnet build src/MklinlUi.WebUI` *(fails: string.Split call ambiguous)*
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689870fda3e883269dd99fff91ea042f