### PR TITLE
feat: add file input for source files

### DIFF
--- a/src/MklinlUi.WebUI/Pages/Index.cshtml
+++ b/src/MklinlUi.WebUI/Pages/Index.cshtml
@@ -16,7 +16,7 @@
             </span>
         </div>
 
-        <form method="post">
+        <form method="post" enctype="multipart/form-data">
             <div class="mb-3">
                 <label class="form-label" asp-for="LinkType">Symlink Type</label>
                 <div>
@@ -31,8 +31,8 @@
                 </div>
             </div>
             <div class="mb-3" id="fileInputs">
-                <label class="form-label" asp-for="SourceFilesInput">Source Files (one per line)</label>
-                <textarea class="form-control" asp-for="SourceFilesInput"></textarea>
+                <label class="form-label" asp-for="SourceFiles">Source Files</label>
+                <input class="form-control" asp-for="SourceFiles" type="file" multiple />
             </div>
 
             <div class="mb-3" id="fileDest">

--- a/src/MklinlUi.WebUI/Pages/Index.cshtml.cs
+++ b/src/MklinlUi.WebUI/Pages/Index.cshtml.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using MklinlUi.Core;
@@ -8,7 +9,7 @@ public sealed class IndexModel(SymlinkManager manager, IDeveloperModeService dev
 {
     [BindProperty] public string LinkType { get; set; } = "File";
 
-    [BindProperty] public string SourceFilesInput { get; set; } = string.Empty;
+    [BindProperty] public List<IFormFile> SourceFiles { get; set; } = [];
 
     [BindProperty] public string DestinationFolder { get; set; } = string.Empty;
 
@@ -45,8 +46,8 @@ public sealed class IndexModel(SymlinkManager manager, IDeveloperModeService dev
             return Page();
         }
 
-        var sourceFiles = SourceFilesInput
-            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+        var sourceFiles = SourceFiles
+            .Select(f => f.FileName)
             .ToList();
         if (sourceFiles.Count == 0 || string.IsNullOrWhiteSpace(DestinationFolder))
         {


### PR DESCRIPTION
## Summary
- use `<input type="file">` for selecting source files
- bind uploaded files in page model and process their names

## Testing
- `dotnet restore`
- `dotnet build src/MklinlUi.Fakes`
- `dotnet build src/MklinlUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689872a8acac8326a09aa57410f23d45