### PR TITLE
Inject logger into SymlinkManager and log failures

### DIFF
--- a/src/MklinlUi.Core/MklinlUi.Core.csproj
+++ b/src/MklinlUi.Core/MklinlUi.Core.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/MklinlUi.Core/SymlinkManager.cs
+++ b/src/MklinlUi.Core/SymlinkManager.cs
@@ -1,9 +1,14 @@
+using Microsoft.Extensions.Logging;
+
 namespace MklinlUi.Core;
 
 /// <summary>
 ///     Coordinates symbolic link creation using provided services.
 /// </summary>
-public sealed class SymlinkManager(IDeveloperModeService developerModeService, ISymlinkService symlinkService)
+public sealed class SymlinkManager(
+    IDeveloperModeService developerModeService,
+    ISymlinkService symlinkService,
+    ILogger<SymlinkManager> logger)
 {
     /// <summary>
     ///     Creates a symbolic link if developer mode is enabled.
@@ -24,7 +29,8 @@ public sealed class SymlinkManager(IDeveloperModeService developerModeService, I
         }
         catch (Exception ex)
         {
-            return new SymlinkResult(false, ex.Message);
+            logger.LogError(ex, "Failed to create symlink from {LinkPath} to {TargetPath}", linkPath, targetPath);
+            return new SymlinkResult(false, "Failed to create symlink.");
         }
     }
 
@@ -47,7 +53,8 @@ public sealed class SymlinkManager(IDeveloperModeService developerModeService, I
         }
         catch (Exception ex)
         {
-            return [new SymlinkResult(false, ex.Message)];
+            logger.LogError(ex, "Failed to create file symlinks in {DestinationFolder}", destinationFolder);
+            return [new SymlinkResult(false, "Failed to create symlinks.")];
         }
     }
 }

--- a/tests/MklinlUi.Tests/FileBatchSymlinkTests.cs
+++ b/tests/MklinlUi.Tests/FileBatchSymlinkTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using MklinlUi.Core;
 using MklinlUi.Fakes;
 using Xunit;
@@ -11,7 +12,7 @@ public class FileBatchSymlinkTests
     public async Task CreateFileSymlinksAsync_creates_links_for_each_file()
     {
         var service = new FakeSymlinkService();
-        var manager = new SymlinkManager(new FakeDeveloperModeService(), service);
+        var manager = new SymlinkManager(new FakeDeveloperModeService(), service, NullLogger<SymlinkManager>.Instance);
 
         const string dest = "/dest";
         var sources = new[] { Path.Combine("/src", "a.txt"), Path.Combine("/src", "b.txt") };
@@ -27,7 +28,7 @@ public class FileBatchSymlinkTests
     public async Task CreateFileSymlinksAsync_skips_on_name_collision()
     {
         var service = new FakeSymlinkService();
-        var manager = new SymlinkManager(new FakeDeveloperModeService(), service);
+        var manager = new SymlinkManager(new FakeDeveloperModeService(), service, NullLogger<SymlinkManager>.Instance);
 
         var sources = new[] { "/src/a.txt", "/other/a.txt" }; // same file name
         var results = await manager.CreateFileSymlinksAsync(sources, "/dest");
@@ -41,7 +42,7 @@ public class FileBatchSymlinkTests
     public async Task CreateFileSymlinksAsync_returns_failure_for_invalid_source()
     {
         var service = new FakeSymlinkService();
-        var manager = new SymlinkManager(new FakeDeveloperModeService(), service);
+        var manager = new SymlinkManager(new FakeDeveloperModeService(), service, NullLogger<SymlinkManager>.Instance);
 
         var results = await manager.CreateFileSymlinksAsync([string.Empty], "/dest");
 

--- a/tests/MklinlUi.Tests/SymlinkManagerTests.cs
+++ b/tests/MklinlUi.Tests/SymlinkManagerTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Moq;
+using Microsoft.Extensions.Logging;
 using MklinlUi.Core;
 using Xunit;
 
@@ -14,8 +15,9 @@ public class SymlinkManagerTests
         devService.Setup(d => d.IsEnabledAsync(It.IsAny<CancellationToken>())).ReturnsAsync(false);
 
         var symlinkService = new Mock<ISymlinkService>();
+        var logger = new Mock<ILogger<SymlinkManager>>();
 
-        var manager = new SymlinkManager(devService.Object, symlinkService.Object);
+        var manager = new SymlinkManager(devService.Object, symlinkService.Object, logger.Object);
 
         var result = await manager.CreateSymlinkAsync("/link", "/target");
 
@@ -33,8 +35,9 @@ public class SymlinkManagerTests
         var symlinkService = new Mock<ISymlinkService>();
         symlinkService.Setup(s => s.CreateSymlinkAsync("/link", "/target", It.IsAny<CancellationToken>()))
                       .ReturnsAsync(new SymlinkResult(true));
+        var logger = new Mock<ILogger<SymlinkManager>>();
 
-        var manager = new SymlinkManager(devService.Object, symlinkService.Object);
+        var manager = new SymlinkManager(devService.Object, symlinkService.Object, logger.Object);
         var result = await manager.CreateSymlinkAsync("/link", "/target");
 
         result.Success.Should().BeTrue();


### PR DESCRIPTION
## Summary
- inject `ILogger<SymlinkManager>` into SymlinkManager
- log exceptions and return generic failure messages instead of raw exception text
- update tests for new logger dependency

## Testing
- `dotnet restore`
- `dotnet build src/MklinlUi.Fakes`
- `dotnet build src/MklinlUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6898852024dc8326be7f3c08b867ffc1