### PR TITLE
Add logging and cancellation handling to Windows symlink service

### DIFF
--- a/src/MklinlUi.Windows/MklinlUi.Windows.csproj
+++ b/src/MklinlUi.Windows/MklinlUi.Windows.csproj
@@ -6,5 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MklinlUi.Core\MklinlUi.Core.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- inject `ILogger<SymlinkService>` and add logging for failures
- check for cancellation while creating batches of symlinks
- map common IO errors to friendly messages
- reference logging abstractions in Windows project

## Testing
- `dotnet restore`
- `dotnet build src/MklinlUi.Windows -p:EnableWindowsTargeting=true`
- `dotnet build src/MklinlUi.Fakes`
- `dotnet build src/MklinlUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689885283d808326bfd2786844740c13