### PR TITLE
Harden symlink creation with filename checks

### DIFF
--- a/src/MklinlUi.WebUI/Pages/Index.cshtml.cs
+++ b/src/MklinlUi.WebUI/Pages/Index.cshtml.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using MklinlUi.Core;
+using System.IO;
 
 namespace MklinlUi.WebUI.Pages;
 
@@ -45,9 +46,27 @@ public sealed class IndexModel(SymlinkManager manager, IDeveloperModeService dev
             return Page();
         }
 
-        var sourceFiles = SourceFiles
-            .Select(f => f.FileName)
-            .ToList();
+        var sourceFiles = new List<string>();
+        foreach (var formFile in SourceFiles)
+        {
+            var name = Path.GetFileName(formFile.FileName);
+            if (string.IsNullOrWhiteSpace(name) || name.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            {
+                Success = false;
+                Message = "One or more file names are invalid.";
+                return Page();
+            }
+
+            if (!System.IO.File.Exists(formFile.FileName))
+            {
+                Success = false;
+                Message = $"Source file not found: {formFile.FileName}.";
+                return Page();
+            }
+
+            sourceFiles.Add(name);
+        }
+
         if (sourceFiles.Count == 0 || string.IsNullOrWhiteSpace(DestinationFolder))
         {
             Success = false;

--- a/tests/MklinlUi.Tests/IndexModelTests.cs
+++ b/tests/MklinlUi.Tests/IndexModelTests.cs
@@ -1,0 +1,52 @@
+using System.IO;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using MklinlUi.Core;
+using MklinlUi.Fakes;
+using MklinlUi.WebUI.Pages;
+using Xunit;
+
+namespace MklinlUi.Tests;
+
+public class IndexModelTests
+{
+    [Fact]
+    public async Task OnPostAsync_returns_error_for_invalid_filename()
+    {
+        var devService = new FakeDeveloperModeService();
+        var manager = new SymlinkManager(devService, new FakeSymlinkService());
+        var model = new IndexModel(manager, devService)
+        {
+            DestinationFolder = "/dest",
+            SourceFiles = [CreateFormFile("")]
+        };
+
+        var result = await model.OnPostAsync();
+
+        model.Success.Should().BeFalse();
+        model.Message.Should().Be("One or more file names are invalid.");
+    }
+
+    [Fact]
+    public async Task OnPostAsync_returns_error_when_source_missing()
+    {
+        var devService = new FakeDeveloperModeService();
+        var manager = new SymlinkManager(devService, new FakeSymlinkService());
+        var model = new IndexModel(manager, devService)
+        {
+            DestinationFolder = "/dest",
+            SourceFiles = [CreateFormFile("missing.txt")]
+        };
+
+        var result = await model.OnPostAsync();
+
+        model.Success.Should().BeFalse();
+        model.Message.Should().Contain("Source file not found");
+    }
+
+    private static IFormFile CreateFormFile(string fileName)
+    {
+        var stream = new MemoryStream();
+        return new FormFile(stream, 0, 0, fileName, fileName);
+    }
+}

--- a/tests/MklinlUi.Tests/MklinlUi.Tests.csproj
+++ b/tests/MklinlUi.Tests/MklinlUi.Tests.csproj
@@ -23,5 +23,6 @@
   <ItemGroup>
     <ProjectReference Include="../../src/MklinlUi.Core/MklinlUi.Core.csproj" />
     <ProjectReference Include="../../src/MklinlUi.Fakes/MklinlUi.Fakes.csproj" />
+    <ProjectReference Include="../../src/MklinlUi.WebUI/MklinlUi.WebUI.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- sanitize uploaded file names and verify existence before creating symlinks
- cover invalid and missing file scenarios with new IndexModel tests

## Testing
- `dotnet restore`
- `dotnet build src/MklinlUi.Fakes`
- `dotnet build src/MklinlUi.WebUI`
- `dotnet test`
- `dotnet format --verify-no-changes`


------
https://chatgpt.com/codex/tasks/task_e_6898853784b483269cc7aa436525eda4