### PR TITLE
Use DI logger and harden developer mode check

### DIFF
--- a/src/MklinlUi.WebUI/Program.cs
+++ b/src/MklinlUi.WebUI/Program.cs
@@ -2,6 +2,8 @@ using System.Net;
 using System.Net.Sockets;
 using MklinlUi.Core;
 using MklinlUi.WebUI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -30,7 +32,10 @@ static int FindPort(int start, int end)
 }
 
 builder.Services.AddRazorPages();
-builder.Services.AddPlatformServices();
+using var serviceProvider = builder.Services.BuildServiceProvider();
+var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+var logger = loggerFactory.CreateLogger("ServiceRegistration");
+builder.Services.AddPlatformServices(logger);
 builder.Services.AddSingleton<SymlinkManager>();
 
 var configuredUrls = builder.Configuration["ASPNETCORE_URLS"];


### PR DESCRIPTION
## Summary
- inject an `ILogger` and report assembly load failures
- check the `MKLINKUI_DEVELOPER_MODE` environment variable rather than assuming developer mode
- wire up service registration with a DI-provided logger

## Testing
- `dotnet restore`
- `dotnet build src/MklinlUi.Fakes`
- `dotnet build src/MklinlUi.WebUI`
- `dotnet test`
- `dotnet format src/MklinlUi.WebUI` *(failed: Unable to fix ASP0000. No associated code fix found.)*

------
https://chatgpt.com/codex/tasks/task_e_68988531fa448326b9638ded7686ecd9