### PR TITLE
Add service registration fallback tests

### DIFF
--- a/src/MklinlUi.WebUI/ServiceRegistration.cs
+++ b/src/MklinlUi.WebUI/ServiceRegistration.cs
@@ -51,7 +51,7 @@ public static class ServiceRegistration
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to load {AssemblyPath}", assemblyPath);
-            throw;
+            return (new DefaultDeveloperModeService(), new DefaultSymlinkService());
         }
 
         static T? Create<T>(Assembly assembly) where T : class

--- a/tests/MklinlUi.Tests/ServiceRegistrationTests.cs
+++ b/tests/MklinlUi.Tests/ServiceRegistrationTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using MklinlUi.Core;
+using MklinlUi.Fakes;
+using MklinlUi.WebUI;
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+
+namespace MklinlUi.Tests;
+
+public class ServiceRegistrationTests
+{
+    [Fact]
+    public void AddPlatformServices_loads_fake_implementations()
+    {
+        var services = new ServiceCollection();
+        services.AddPlatformServices(NullLogger.Instance);
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IDeveloperModeService>()
+            .Should().BeOfType<FakeDeveloperModeService>();
+        provider.GetRequiredService<ISymlinkService>()
+            .Should().BeOfType<FakeSymlinkService>();
+    }
+
+    [Fact]
+    public void AddPlatformServices_uses_defaults_when_assembly_missing()
+    {
+        var assemblyPath = Path.Combine(AppContext.BaseDirectory, "MklinlUi.Fakes.dll");
+        var backupPath = assemblyPath + ".bak";
+        File.Move(assemblyPath, backupPath);
+        try
+        {
+            var services = new ServiceCollection();
+            services.AddPlatformServices(NullLogger.Instance);
+
+            using var provider = services.BuildServiceProvider();
+            provider.GetRequiredService<IDeveloperModeService>().GetType().FullName
+                .Should().Be("MklinlUi.WebUI.ServiceRegistration+DefaultDeveloperModeService");
+            provider.GetRequiredService<ISymlinkService>().GetType().FullName
+                .Should().Be("MklinlUi.WebUI.ServiceRegistration+DefaultSymlinkService");
+        }
+        finally
+        {
+            File.Move(backupPath, assemblyPath);
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary
- test service registration loads fake implementations
- ensure service registration falls back to built-in defaults when assembly missing
- handle assembly load failures by returning default services

## Testing
- `dotnet restore`
- `dotnet build src/MklinlUi.Fakes`
- `dotnet build src/MklinlUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689acd5dad5883268279beae9aecabb8