### PR TITLE
Respect cancellation in file symlink creation

### DIFF
--- a/src/MklinlUi.Fakes/FakeSymlinkService.cs
+++ b/src/MklinlUi.Fakes/FakeSymlinkService.cs
@@ -29,20 +29,26 @@ public sealed class FakeSymlinkService : ISymlinkService
         ArgumentNullException.ThrowIfNull(sourceFiles);
         ArgumentException.ThrowIfNullOrWhiteSpace(destinationFolder);
 
+        cancellationToken.ThrowIfCancellationRequested();
+
         var results = new List<SymlinkResult>();
         foreach (var source in sourceFiles)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (string.IsNullOrWhiteSpace(source))
             {
                 results.Add(new SymlinkResult(false, "Invalid source."));
                 continue;
             }
+
             var link = Path.Combine(destinationFolder, Path.GetFileName(source));
             if (_created.Any(c => string.Equals(c.LinkPath, link, StringComparison.OrdinalIgnoreCase)))
             {
                 results.Add(new SymlinkResult(false, "Link already exists."));
                 continue;
             }
+
             _created.Add((link, source));
             results.Add(new SymlinkResult(true));
         }


### PR DESCRIPTION
## Summary
- honor cancellation at the beginning and per-file iteration when faking file symlink creation
- add cancellation token tests for file batch symlink creation

## Testing
- `dotnet restore`
- `dotnet build src/MklinlUi.Fakes`
- `dotnet build src/MklinlUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689acd677e608326a549eab6987adc30