### PR TITLE
Refine port availability logging

### DIFF
--- a/src/MklinlUi.WebUI/Program.cs
+++ b/src/MklinlUi.WebUI/Program.cs
@@ -58,7 +58,7 @@ static bool PortAvailable(int port, ILogger logger)
     }
     catch (SocketException ex)
     {
-        logger.LogError(ex, "Port {Port} is unavailable", port);
+        logger.LogDebug(ex, "Port {Port} is unavailable", port);
         return false;
     }
 }


### PR DESCRIPTION
## Summary
- log PortAvailable failures at debug level rather than error
- retain error logging in FindPort when no ports are free

## Testing
- `dotnet restore`
- `dotnet build src/MklinlUi.Fakes`
- `dotnet build src/MklinlUi.WebUI`
- `dotnet test`
- `dotnet format src/MklinlUi.WebUI --verify-no-changes -v diag`


------
https://chatgpt.com/codex/tasks/task_e_689acd696ed08326bb154d61de5dccdb