### PR TITLE
Handle symlink creation errors

### DIFF
--- a/tests/MklinlUi.Tests/IndexModelTests.cs
+++ b/tests/MklinlUi.Tests/IndexModelTests.cs
@@ -4,6 +4,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using MklinlUi.Core;
 using MklinlUi.Fakes;
 using MklinlUi.WebUI.Pages;
+using System.IO;
+using System.Threading;
 using Xunit;
 
 namespace MklinlUi.Tests;
@@ -15,7 +17,7 @@ public class IndexModelTests
     {
         var devService = new FakeDeveloperModeService();
         var manager = new SymlinkManager(devService, new FakeSymlinkService(), NullLogger<SymlinkManager>.Instance);
-        var model = new IndexModel(manager, devService)
+        var model = new IndexModel(manager, devService, NullLogger<IndexModel>.Instance)
         {
             DestinationFolder = "/dest",
             SourceFiles = [CreateFormFile("")]
@@ -32,7 +34,7 @@ public class IndexModelTests
     {
         var devService = new FakeDeveloperModeService();
         var manager = new SymlinkManager(devService, new FakeSymlinkService(), NullLogger<SymlinkManager>.Instance);
-        var model = new IndexModel(manager, devService)
+        var model = new IndexModel(manager, devService, NullLogger<IndexModel>.Instance)
         {
             DestinationFolder = "/dest",
             SourceFiles = [CreateFormFile("missing.txt")]
@@ -42,6 +44,58 @@ public class IndexModelTests
 
         model.Success.Should().BeFalse();
         model.Message.Should().Contain("Source file not found");
+    }
+
+    [Fact]
+    public async Task OnPostAsync_returns_error_when_create_symlink_throws()
+    {
+        var devService = new ThrowingDeveloperModeService();
+        var manager = new SymlinkManager(devService, new FakeSymlinkService(), NullLogger<SymlinkManager>.Instance);
+        var model = new IndexModel(manager, devService, NullLogger<IndexModel>.Instance)
+        {
+            LinkType = "Folder",
+            SourcePath = "/src",
+            DestinationPath = "/dest"
+        };
+
+        await model.OnPostAsync();
+
+        model.Success.Should().BeFalse();
+        model.Message.Should().Be("An unexpected error occurred while creating the symlink.");
+    }
+
+    [Fact]
+    public async Task OnPostAsync_returns_error_when_create_file_symlinks_throws()
+    {
+        var tempFile = Path.GetTempFileName();
+        var devService = new ThrowingDeveloperModeService();
+        var manager = new SymlinkManager(devService, new FakeSymlinkService(), NullLogger<SymlinkManager>.Instance);
+        var model = new IndexModel(manager, devService, NullLogger<IndexModel>.Instance)
+        {
+            DestinationFolder = "/dest",
+            SourceFiles = [CreateFormFile(tempFile)]
+        };
+
+        await model.OnPostAsync();
+
+        model.Success.Should().BeFalse();
+        model.Message.Should().Be("An unexpected error occurred while creating file symlinks.");
+    }
+
+    private sealed class ThrowingDeveloperModeService : IDeveloperModeService
+    {
+        private bool first = true;
+
+        public Task<bool> IsEnabledAsync(CancellationToken cancellationToken = default)
+        {
+            if (first)
+            {
+                first = false;
+                return Task.FromResult(true);
+            }
+
+            throw new InvalidOperationException("Failure");
+        }
     }
 
     private static FormFile CreateFormFile(string fileName)


### PR DESCRIPTION
## Summary
- log and report errors when symlink creation fails in the Index page
- test that IndexModel handles exceptions from symlink creation

## Testing
- `dotnet restore`
- `dotnet build src/MklinlUi.Fakes`
- `dotnet build src/MklinlUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689acd6a30548326984f7b433887bee1