### PR TITLE
Support full source paths in file symlink creation

### DIFF
--- a/src/MklinlUi.WebUI/Pages/Index.cshtml
+++ b/src/MklinlUi.WebUI/Pages/Index.cshtml
@@ -16,7 +16,7 @@
             </span>
         </div>
 
-        <form method="post" enctype="multipart/form-data">
+        <form method="post">
             <div class="mb-3">
                 <label class="form-label" asp-for="LinkType">Symlink Type</label>
                 <div>
@@ -31,12 +31,8 @@
                 </div>
             </div>
             <div class="mb-3" id="fileInputs">
-                <label class="form-label" asp-for="SourceFiles">Source Files</label>
-                <div class="input-group">
-                    <input class="form-control" id="sourceFiles" readonly />
-                    <button type="button" class="btn btn-outline-secondary" onclick="document.getElementById('sourceFilesInput').click()"><i class="fa-solid fa-folder-open me-1"></i>Browse</button>
-                </div>
-                <input class="d-none" asp-for="SourceFiles" id="sourceFilesInput" type="file" multiple onchange="document.getElementById('sourceFiles').value = Array.from(this.files).map(f => f.name).join(', ')">
+                <label class="form-label" asp-for="SourceFilePaths">Source File Paths</label>
+                <textarea class="form-control" asp-for="SourceFilePaths" rows="3"></textarea>
             </div>
 
             <div class="mb-3" id="fileDest">


### PR DESCRIPTION
## Summary
- allow entering full file paths for file symlinks
- update UI to accept newline separated file paths
- add tests verifying successful file symlink creation

## Testing
- `dotnet restore`
- `dotnet build src/MklinlUi.Fakes`
- `dotnet build src/MklinlUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689acd6af8d48326af9b03d65f1d7f06