### PR TITLE
Fallback to default services when platform assembly missing

### DIFF
--- a/src/MklinlUi.WebUI/ServiceRegistration.cs
+++ b/src/MklinlUi.WebUI/ServiceRegistration.cs
@@ -19,10 +19,19 @@ public static class ServiceRegistration
             : "MklinlUi.Fakes.dll";
         var assemblyPath = Path.Combine(AppContext.BaseDirectory, assemblyName);
 
-        var (dev, sym) = TryLoadServices(assemblyPath, logger);
+        try
+        {
+            var (dev, sym) = TryLoadServices(assemblyPath, logger);
 
-        services.AddSingleton(dev);
-        services.AddSingleton(sym);
+            services.AddSingleton(dev);
+            services.AddSingleton(sym);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Falling back to default services");
+            services.AddSingleton<IDeveloperModeService>(new DefaultDeveloperModeService());
+            services.AddSingleton<ISymlinkService>(new DefaultSymlinkService());
+        }
 
         return services;
     }

--- a/tests/MklinlUi.Tests/ServiceRegistrationTests.cs
+++ b/tests/MklinlUi.Tests/ServiceRegistrationTests.cs
@@ -1,0 +1,45 @@
+using System;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using MklinlUi.Core;
+using MklinlUi.WebUI;
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+
+namespace MklinlUi.Tests;
+
+public class ServiceRegistrationTests
+{
+    [Fact]
+    public void AddPlatformServices_RegistersDefaults_WhenAssemblyMissing()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var logger = NullLogger.Instance;
+
+        var originalBase = AppContext.BaseDirectory;
+        var tempDir = Directory.CreateTempSubdirectory();
+        AppDomain.CurrentDomain.SetData("APP_CONTEXT_BASE_DIRECTORY", tempDir.FullName);
+
+        try
+        {
+            // Act
+            services.AddPlatformServices(logger);
+            using var provider = services.BuildServiceProvider();
+            var dev = provider.GetRequiredService<IDeveloperModeService>();
+            var sym = provider.GetRequiredService<ISymlinkService>();
+
+            // Assert
+            dev.GetType().Name.Should().Be("DefaultDeveloperModeService");
+            sym.GetType().Name.Should().Be("DefaultSymlinkService");
+        }
+        finally
+        {
+            AppDomain.CurrentDomain.SetData("APP_CONTEXT_BASE_DIRECTORY", originalBase);
+            tempDir.Delete();
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- handle missing platform assembly by falling back to internal services
- add unit test covering default service registration

## Testing
- `dotnet restore`
- `dotnet build src/MklinlUi.Fakes`
- `dotnet build src/MklinlUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689acd6d0c108326afb3817daa5c2f8d