### PR TITLE
Handle cancellation and existing links in SymlinkService

### DIFF
--- a/src/MklinlUi.Windows/SymlinkService.cs
+++ b/src/MklinlUi.Windows/SymlinkService.cs
@@ -17,6 +17,11 @@ public sealed class SymlinkService(ILogger<SymlinkService>? logger = null) : ISy
         ArgumentException.ThrowIfNullOrWhiteSpace(linkPath);
         ArgumentException.ThrowIfNullOrWhiteSpace(targetPath);
 
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (File.Exists(linkPath) || Directory.Exists(linkPath))
+            return Task.FromResult(new SymlinkResult(false, "Link already exists."));
+
         try
         {
             if (Directory.Exists(targetPath))

--- a/tests/MklinlUi.Windows.Tests/SymlinkServiceTests.cs
+++ b/tests/MklinlUi.Windows.Tests/SymlinkServiceTests.cs
@@ -1,17 +1,18 @@
 #if WINDOWS
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
 
 namespace MklinlUi.Windows.Tests;
 
-public class SymlinkServiceTests
-{
-    [Fact]
-    public async Task CreateFileSymlinksAsync_creates_file_links()
+    public class SymlinkServiceTests
     {
+        [Fact]
+        public async Task CreateFileSymlinksAsync_creates_file_links()
+        {
         var service = new SymlinkService();
         var temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(temp);
@@ -27,6 +28,36 @@ public class SymlinkServiceTests
         var link = Path.Combine(dest, "source.txt");
         File.Exists(link).Should().BeTrue();
         File.GetAttributes(link).HasFlag(FileAttributes.Directory).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CreateSymlinkAsync_throws_when_cancelled()
+    {
+        var service = new SymlinkService();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = () => service.CreateSymlinkAsync("link", "target", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task CreateSymlinkAsync_returns_failure_if_link_exists()
+    {
+        var service = new SymlinkService();
+        var temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(temp);
+        var target = Path.Combine(temp, "target.txt");
+        await File.WriteAllTextAsync(target, "data");
+        var link = Path.Combine(temp, "link.txt");
+        await File.WriteAllTextAsync(link, "existing");
+
+        var result = await service.CreateSymlinkAsync(link, target);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Be("Link already exists.");
+        File.GetAttributes(link).HasFlag(FileAttributes.ReparsePoint).Should().BeFalse();
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- cancel CreateSymlinkAsync if the operation is already cancelled
- prevent link creation when a link path already exists
- test cancellation and existing link scenarios for the Windows symlink service

## Testing
- `dotnet restore`
- `dotnet build src/MklinlUi.Windows`
- `dotnet build src/MklinlUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689acd6dde2c8326ac4c2c53d763b954