### PR TITLE
Return per-file failures for batch symlink errors

### DIFF
--- a/src/MklinlUi.Core/SymlinkManager.cs
+++ b/src/MklinlUi.Core/SymlinkManager.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using System.Linq;
 
 namespace MklinlUi.Core;
 
@@ -43,18 +44,23 @@ public sealed class SymlinkManager(
         ArgumentNullException.ThrowIfNull(sourceFiles);
         ArgumentException.ThrowIfNullOrWhiteSpace(destinationFolder);
 
+        var sources = sourceFiles.ToList();
         if (!await developerModeService.IsEnabledAsync(cancellationToken).ConfigureAwait(false))
-            return [new SymlinkResult(false, "Developer mode not enabled.")];
+            return Enumerable.Range(0, sources.Count)
+                .Select(_ => new SymlinkResult(false, "Developer mode not enabled."))
+                .ToList();
 
         try
         {
-            return await symlinkService.CreateFileSymlinksAsync(sourceFiles, destinationFolder, cancellationToken)
+            return await symlinkService.CreateFileSymlinksAsync(sources, destinationFolder, cancellationToken)
                 .ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to create file symlinks in {DestinationFolder}", destinationFolder);
-            return [new SymlinkResult(false, "Failed to create symlinks.")];
+            return Enumerable.Range(0, sources.Count)
+                .Select(_ => new SymlinkResult(false, "Failed to create symlinks."))
+                .ToList();
         }
     }
 }

--- a/tests/MklinlUi.Tests/FileBatchSymlinkTests.cs
+++ b/tests/MklinlUi.Tests/FileBatchSymlinkTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using MklinlUi.Core;
 using MklinlUi.Fakes;
+using Moq;
 using Xunit;
 
 namespace MklinlUi.Tests;
@@ -48,5 +49,37 @@ public class FileBatchSymlinkTests
 
         results.Should().HaveCount(1);
         results[0].Success.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CreateFileSymlinksAsync_returns_failures_when_developer_mode_disabled()
+    {
+        var dev = new FakeDeveloperModeService { Enabled = false };
+        var service = new FakeSymlinkService();
+        var manager = new SymlinkManager(dev, service, NullLogger<SymlinkManager>.Instance);
+
+        var sources = new[] { "/src/a.txt", "/src/b.txt" };
+        var results = await manager.CreateFileSymlinksAsync(sources, "/dest");
+
+        results.Should().HaveCount(2);
+        results.Should().OnlyContain(r => !r.Success && r.ErrorMessage == "Developer mode not enabled.");
+        service.Created.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateFileSymlinksAsync_returns_failures_when_service_throws()
+    {
+        var dev = new FakeDeveloperModeService();
+        var service = new Mock<ISymlinkService>();
+        service.Setup(s => s.CreateFileSymlinksAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+        var manager = new SymlinkManager(dev, service.Object, NullLogger<SymlinkManager>.Instance);
+
+        var sources = new[] { "/src/a.txt", "/src/b.txt" };
+        var results = await manager.CreateFileSymlinksAsync(sources, "/dest");
+
+        results.Should().HaveCount(2);
+        results.Should().OnlyContain(r => !r.Success && r.ErrorMessage == "Failed to create symlinks.");
+        service.Verify(s => s.CreateFileSymlinksAsync(It.IsAny<IEnumerable<string>>(), "/dest", It.IsAny<CancellationToken>()), Times.Once);
     }
 }


### PR DESCRIPTION
## Summary
- Ensure `CreateFileSymlinksAsync` returns a failure for each source when developer mode is disabled or an exception occurs
- Expand batch symlink tests to cover disabled developer mode and service exceptions

## Testing
- `dotnet restore`
- `dotnet build src/MklinlUi.Fakes`
- `dotnet build src/MklinlUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689acd6fa398832691cfd87dcac7fae5