### PR TITLE
Warn when developer mode disabled before symlink creation

### DIFF
--- a/src/MklinlUi.Core/SymlinkManager.cs
+++ b/src/MklinlUi.Core/SymlinkManager.cs
@@ -20,7 +20,13 @@ public sealed class SymlinkManager(
         ArgumentException.ThrowIfNullOrWhiteSpace(targetPath);
 
         if (!await developerModeService.IsEnabledAsync(cancellationToken).ConfigureAwait(false))
+        {
+            logger.LogWarning(
+                "Developer mode not enabled; skipping symlink from {LinkPath} to {TargetPath}",
+                linkPath,
+                targetPath);
             return new SymlinkResult(false, "Developer mode not enabled.");
+        }
 
         try
         {
@@ -44,7 +50,12 @@ public sealed class SymlinkManager(
         ArgumentException.ThrowIfNullOrWhiteSpace(destinationFolder);
 
         if (!await developerModeService.IsEnabledAsync(cancellationToken).ConfigureAwait(false))
+        {
+            logger.LogWarning(
+                "Developer mode not enabled; skipping file symlinks in {DestinationFolder}",
+                destinationFolder);
             return [new SymlinkResult(false, "Developer mode not enabled.")];
+        }
 
         try
         {


### PR DESCRIPTION
## Summary
- log warnings in SymlinkManager when developer mode is off
- assert warning logs in SymlinkManager tests

## Testing
- `dotnet restore`
- `dotnet build src/MklinlUi.Fakes`
- `dotnet build src/MklinlUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689acd70908c8326a80d1e10b544e4c9