### PR TITLE
Align tests with IndexModel API and handle registry errors

### DIFF
--- a/tests/MklinlUi.Tests/IndexModelTests.cs
+++ b/tests/MklinlUi.Tests/IndexModelTests.cs
@@ -1,5 +1,4 @@
 using FluentAssertions;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using MklinlUi.Core;
 using MklinlUi.Fakes;
@@ -17,11 +16,10 @@ public class IndexModelTests
     {
         var devService = new FakeDeveloperModeService();
         var manager = new SymlinkManager(devService, new FakeSymlinkService(), NullLogger<SymlinkManager>.Instance);
-        var model = new IndexModel(manager, devService)
         var model = new IndexModel(manager, devService, NullLogger<IndexModel>.Instance)
         {
             DestinationFolder = "/dest",
-            SourceFiles = [CreateFormFile("")]
+            SourceFilePaths = "/invalid|name.txt"
         };
 
         await model.OnPostAsync();
@@ -35,11 +33,10 @@ public class IndexModelTests
     {
         var devService = new FakeDeveloperModeService();
         var manager = new SymlinkManager(devService, new FakeSymlinkService(), NullLogger<SymlinkManager>.Instance);
-        var model = new IndexModel(manager, devService)
         var model = new IndexModel(manager, devService, NullLogger<IndexModel>.Instance)
         {
             DestinationFolder = "/dest",
-            SourceFiles = [CreateFormFile("missing.txt")]
+            SourceFilePaths = Path.Combine(Path.GetTempPath(), "missing.txt")
         };
 
         await model.OnPostAsync();
@@ -75,7 +72,7 @@ public class IndexModelTests
         var model = new IndexModel(manager, devService, NullLogger<IndexModel>.Instance)
         {
             DestinationFolder = "/dest",
-            SourceFiles = [CreateFormFile(tempFile)]
+            SourceFilePaths = tempFile
         };
 
         await model.OnPostAsync();
@@ -100,9 +97,4 @@ public class IndexModelTests
         }
     }
 
-    private static FormFile CreateFormFile(string fileName)
-    {
-        var stream = new MemoryStream();
-        return new FormFile(stream, 0, 0, fileName, fileName);
-    }
 }

--- a/tests/MklinlUi.Windows.Tests/DeveloperModeServiceTests.cs
+++ b/tests/MklinlUi.Windows.Tests/DeveloperModeServiceTests.cs
@@ -73,13 +73,31 @@ public class DeveloperModeServiceTests
         }
     }
 
-    private static void OverrideHKLM(RegistryKey key) =>
-        RegOverridePredefKey((UIntPtr)HKEY_LOCAL_MACHINE, key.Handle.DangerousGetHandle());
+    private static void OverrideHKLM(RegistryKey key)
+    {
+        var result = RegOverridePredefKey((UIntPtr)HKEY_LOCAL_MACHINE, key.Handle.DangerousGetHandle());
+        if (result != 0)
+        {
+            throw new InvalidOperationException($"RegOverridePredefKey failed with error {result}");
+        }
+    }
 
-    private static void OverrideHKLM(IntPtr handle) =>
-        RegOverridePredefKey((UIntPtr)HKEY_LOCAL_MACHINE, handle);
+    private static void OverrideHKLM(IntPtr handle)
+    {
+        var result = RegOverridePredefKey((UIntPtr)HKEY_LOCAL_MACHINE, handle);
+        if (result != 0)
+        {
+            throw new InvalidOperationException($"RegOverridePredefKey failed with error {result}");
+        }
+    }
 
-    private static void RestoreHKLM() =>
-        RegOverridePredefKey((UIntPtr)HKEY_LOCAL_MACHINE, IntPtr.Zero);
+    private static void RestoreHKLM()
+    {
+        var result = RegOverridePredefKey((UIntPtr)HKEY_LOCAL_MACHINE, IntPtr.Zero);
+        if (result != 0)
+        {
+            throw new InvalidOperationException($"RegOverridePredefKey failed with error {result}");
+        }
+    }
 }
 #endif


### PR DESCRIPTION
## Summary
- update IndexModel tests to use `SourceFilePaths` instead of obsolete `SourceFiles`
- check return values from `RegOverridePredefKey` in Windows tests

## Testing
- `dotnet restore`
- `dotnet build src/MklinlUi.Fakes` *(fails: SymlinkManager.cs(56,115): error CS1002)*
- `dotnet build src/MklinlUi.WebUI` *(fails: SymlinkManager.cs(56,115): error CS1002)*
- `dotnet test` *(fails: SymlinkManager.cs(56,115): error CS1002)*

------
https://chatgpt.com/codex/tasks/task_e_689aded8cbb483268b2a2a3f2414253d