### PR TITLE
Fix SymlinkResult usage and clean up SymlinkManager

### DIFF
--- a/src/MklinlUi.Core/SymlinkManager.cs
+++ b/src/MklinlUi.Core/SymlinkManager.cs
@@ -20,7 +20,10 @@ public sealed class SymlinkManager(
         ArgumentException.ThrowIfNullOrWhiteSpace(targetPath);
 
         if (!await developerModeService.IsEnabledAsync(cancellationToken).ConfigureAwait(false))
+        {
+            logger.LogWarning("Developer mode not enabled.");
             return new SymlinkResult(false, "Developer mode not enabled.");
+        }
 
         try
         {
@@ -45,24 +48,21 @@ public sealed class SymlinkManager(
 
         var sources = sourceFiles.ToList();
         if (!await developerModeService.IsEnabledAsync(cancellationToken).ConfigureAwait(false))
-            return [new SymlinkResult(false, "Developer mode not enabled.")];
-        return Enumerable.Range(0, sources.Count)
-            .Select(_ => new SymlinkResult(false, "Developer mode not enabled."))
-            .ToList();
+        {
+            logger.LogWarning("Developer mode not enabled.");
+            return sources.Select(_ => new SymlinkResult(false, "Developer mode not enabled.")).ToList();
+        }
 
         try
         {
-            return await symlinkService.CreateFileSymlinksAsync(sourceFiles, destinationFolder, cancellationToken);
-            return await symlinkService.CreateFileSymlinksAsync(sources, destinationFolder, cancellationToken)
+            return await symlinkService
+                .CreateFileSymlinksAsync(sources, destinationFolder, cancellationToken)
                 .ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to create file symlinks in {DestinationFolder}", destinationFolder);
-            return [new SymlinkResult(false, "Failed to create symlinks.")];
-            return Enumerable.Range(0, sources.Count)
-                .Select(_ => new SymlinkResult(false, "Failed to create symlinks."))
-                .ToList();
+            return sources.Select(_ => new SymlinkResult(false, "Failed to create symlinks.")).ToList();
         }
     }
 }

--- a/tests/MklinlUi.Tests/IndexModelTests.cs
+++ b/tests/MklinlUi.Tests/IndexModelTests.cs
@@ -16,10 +16,11 @@ public class IndexModelTests
     {
         var devService = new FakeDeveloperModeService();
         var manager = new SymlinkManager(devService, new FakeSymlinkService(), NullLogger<SymlinkManager>.Instance);
+        var invalidChar = Path.GetInvalidFileNameChars().First();
         var model = new IndexModel(manager, devService, NullLogger<IndexModel>.Instance)
         {
             DestinationFolder = "/dest",
-            SourceFilePaths = "/invalid|name.txt"
+            SourceFilePaths = $"/invalid{invalidChar}name.txt"
         };
 
         await model.OnPostAsync();

--- a/tests/MklinlUi.Windows.Tests/SymlinkServiceTests.cs
+++ b/tests/MklinlUi.Windows.Tests/SymlinkServiceTests.cs
@@ -56,7 +56,7 @@ public class SymlinkServiceTests
         var result = await service.CreateSymlinkAsync(link, target);
 
         result.Success.Should().BeFalse();
-        result.Message.Should().Be("Link already exists.");
+        result.ErrorMessage.Should().Be("Link already exists.");
         File.GetAttributes(link).HasFlag(FileAttributes.ReparsePoint).Should().BeFalse();
     }
 }


### PR DESCRIPTION
## Summary
- add developer mode warnings and remove unreachable code in `SymlinkManager`
- align Windows symlink service tests with `SymlinkResult.ErrorMessage`
- make invalid filename test OS-agnostic

## Testing
- `dotnet restore`
- `dotnet build src/MklinlUi.Fakes`
- `dotnet build src/MklinlUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689ae3f23a2c8326a12fa750d99c6c7f