### PR TITLE
Use LibraryImport for RegOverridePredefKey

### DIFF
--- a/tests/MklinlUi.Windows.Tests/DeveloperModeServiceTests.cs
+++ b/tests/MklinlUi.Windows.Tests/DeveloperModeServiceTests.cs
@@ -8,12 +8,12 @@ using Xunit;
 
 namespace MklinlUi.Windows.Tests;
 
-public class DeveloperModeServiceTests
+public partial class DeveloperModeServiceTests
 {
     private const uint HKEY_LOCAL_MACHINE = 0x80000002;
 
-    [DllImport("advapi32.dll", SetLastError = true)]
-    private static extern int RegOverridePredefKey(UIntPtr hKey, IntPtr hNewKey);
+    [LibraryImport("advapi32.dll", SetLastError = true)]
+    private static partial int RegOverridePredefKey(UIntPtr hKey, IntPtr hNewKey);
 
     [Fact]
     public async Task IsEnabledAsync_returns_false_on_non_Windows()


### PR DESCRIPTION
## Summary
- replace DllImport with LibraryImport for RegOverridePredefKey in Windows-only test

## Testing
- `dotnet restore`
- `dotnet build src/MklinlUi.Fakes`
- `dotnet build src/MklinlUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689ae660a6408326a6a976285d485b2b