### PR TITLE
Add CI workflow and Dockerfile for production readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Restore
+      run: dotnet restore
+
+    - name: Build non-Windows projects
+      if: runner.os != 'Windows'
+      run: |
+        dotnet build src/MklinkUi.Fakes -c Release --no-restore
+        dotnet build src/MklinkUi.WebUI -c Release --no-restore
+
+    - name: Build Windows projects
+      if: runner.os == 'Windows'
+      run: |
+        dotnet build src/MklinkUi.Windows -c Release --no-restore
+        dotnet build src/MklinkUi.WebUI -c Release --no-restore
+
+    - name: Run tests
+      run: dotnet test --no-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+COPY MklinkUi.sln ./
+COPY src ./src
+
+RUN dotnet restore
+RUN dotnet build src/MklinkUi.Fakes -c Release
+RUN dotnet publish src/MklinkUi.WebUI -c Release -o /app
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
+WORKDIR /app
+ENV ASPNETCORE_URLS=http://+:8080
+COPY --from=build /app .
+ENTRYPOINT ["dotnet", "MklinkUi.WebUI.dll"]

--- a/README.md
+++ b/README.md
@@ -76,3 +76,15 @@ The dark-themed web interface centers its main card on screen for common desktop
 
 By default the app binds to HTTP port **5280** (and HTTPS **5281** when a certificate is configured). Override with the `ASPNETCORE_URLS` environment variable or `Server:Port` in `appsettings.json`.
 
+
+## Continuous integration
+A GitHub Actions workflow runs on every push and pull request to build the application on Linux and Windows and execute the full test suite.
+
+## Docker
+A multi-stage `Dockerfile` is available to publish and run MklinkUI in a container.
+
+### Build and run
+```bash
+docker build -t mklinkui .
+docker run --rm -p 8080:8080 mklinkui
+```

--- a/src/MklinkUi.WebUI/Pages/Index.cshtml.cs
+++ b/src/MklinkUi.WebUI/Pages/Index.cshtml.cs
@@ -64,7 +64,7 @@ public sealed class IndexModel(
         }
 
         var sourceFiles = SourceFilePaths
-            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .ToList();
 
         if (sourceFiles.Count == 0 || string.IsNullOrWhiteSpace(DestinationFolder))


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and test on Linux and Windows
- provide Dockerfile for containerized deployment
- fix ambiguous string.Split call in Index page
- document CI pipeline and Docker usage in README

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes -c Release`
- `dotnet build src/MklinkUi.WebUI -c Release`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b04846d0c8326901428e16749efb2