### PR TITLE
Support numeric developer mode environment values

### DIFF
--- a/src/MklinkUi.WebUI/ServiceRegistration.cs
+++ b/src/MklinkUi.WebUI/ServiceRegistration.cs
@@ -78,14 +78,18 @@ public static class ServiceRegistration
     {
         public Task<bool> IsEnabledAsync(CancellationToken cancellationToken = default)
         {
-            if (!OperatingSystem.IsWindows())
+            var value = Environment.GetEnvironmentVariable("MKLINKUI_DEVELOPER_MODE");
+
+            if (!string.IsNullOrWhiteSpace(value))
             {
-                return Task.FromResult(true);
+                if (bool.TryParse(value, out var parsedBool))
+                    return Task.FromResult(parsedBool);
+
+                if (int.TryParse(value, out var parsedInt))
+                    return Task.FromResult(parsedInt != 0);
             }
 
-            return Task.FromResult(string.Equals(
-                Environment.GetEnvironmentVariable("MKLINKUI_DEVELOPER_MODE"),
-                "true", StringComparison.OrdinalIgnoreCase));
+            return Task.FromResult(!OperatingSystem.IsWindows());
         }
     }
 

--- a/tests/MklinkUi.Tests/ServiceRegistrationTests.cs
+++ b/tests/MklinkUi.Tests/ServiceRegistrationTests.cs
@@ -25,11 +25,11 @@ public class ServiceRegistrationTests
 
         try
         {
-                // Act
-                services.AddPlatformServices();
-                using var provider = services.BuildServiceProvider();
-                var dev = provider.GetRequiredService<IDeveloperModeService>();
-                var sym = provider.GetRequiredService<ISymlinkService>();
+            // Act
+            services.AddPlatformServices();
+            using var provider = services.BuildServiceProvider();
+            var dev = provider.GetRequiredService<IDeveloperModeService>();
+            var sym = provider.GetRequiredService<ISymlinkService>();
 
             // Assert
             dev.GetType().Name.Should().Be("DefaultDeveloperModeService");
@@ -39,6 +39,40 @@ public class ServiceRegistrationTests
         {
             AppDomain.CurrentDomain.SetData("APP_CONTEXT_BASE_DIRECTORY", originalBase);
             tempDir.Delete();
+        }
+    }
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("true", true)]
+    [InlineData("1", true)]
+    [InlineData("false", false)]
+    [InlineData("0", false)]
+    public async Task DefaultDeveloperModeService_Reads_EnvironmentVariable(string? value, bool expected)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var originalBase = AppContext.BaseDirectory;
+        var tempDir = Directory.CreateTempSubdirectory();
+        AppDomain.CurrentDomain.SetData("APP_CONTEXT_BASE_DIRECTORY", tempDir.FullName);
+
+        var originalEnv = Environment.GetEnvironmentVariable("MKLINKUI_DEVELOPER_MODE");
+        Environment.SetEnvironmentVariable("MKLINKUI_DEVELOPER_MODE", value);
+
+        try
+        {
+            services.AddPlatformServices();
+            using var provider = services.BuildServiceProvider();
+            var dev = provider.GetRequiredService<IDeveloperModeService>();
+            var enabled = await dev.IsEnabledAsync();
+            enabled.Should().Be(expected);
+        }
+        finally
+        {
+            AppDomain.CurrentDomain.SetData("APP_CONTEXT_BASE_DIRECTORY", originalBase);
+            tempDir.Delete();
+            Environment.SetEnvironmentVariable("MKLINKUI_DEVELOPER_MODE", originalEnv);
         }
     }
 }


### PR DESCRIPTION
## Summary
- parse MKLINKUI_DEVELOPER_MODE as boolean or numeric to determine developer mode status
- verify default developer mode service honors environment variable settings

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`
- `dotnet format`

------
https://chatgpt.com/codex/tasks/task_e_689b2772b17083269b31ac3e712cc669