### PR TITLE
feat: support multi-file browsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The published files are in `src/MklinkUi.WebUI/bin/Release/net8.0/publish`.
 - The web UI is minimal and lacks comprehensive error handling.
 - On non-Windows platforms, the developer mode check always reports enabled.
 - Creating symbolic links may require elevated privileges or Windows Developer Mode.
+- Browser file pickers cannot expose absolute file paths, so only file names are captured when selecting files.
 
 ## Web interface
 

--- a/src/MklinkUi.WebUI/Pages/Index.cshtml
+++ b/src/MklinkUi.WebUI/Pages/Index.cshtml
@@ -32,7 +32,10 @@
             </div>
             <div class="mb-3" id="fileInputs">
                 <label class="form-label" asp-for="SourceFilePaths">Source File Paths</label>
-                <textarea class="form-control" asp-for="SourceFilePaths" rows="3"></textarea>
+                <div class="input-group">
+                    <textarea class="form-control" asp-for="SourceFilePaths" rows="3"></textarea>
+                    <button type="button" class="btn btn-outline-secondary" onclick="browseFile('SourceFilePaths', true)"><i class="fa-solid fa-file-import me-1"></i>Browse Files…</button>
+                </div>
             </div>
 
             <div class="mb-3" id="fileDest">

--- a/src/MklinkUi.WebUI/wwwroot/js/site.js
+++ b/src/MklinkUi.WebUI/wwwroot/js/site.js
@@ -1,17 +1,23 @@
 // File and folder browsers
-async function browseFile(inputId) {
+// Browsers limit access to absolute file paths for security, so only file names are available.
+async function browseFile(inputId, allowMultiple = false) {
+    const target = document.getElementById(inputId);
     if (window.showOpenFilePicker) {
         try {
-            const [handle] = await window.showOpenFilePicker();
-            document.getElementById(inputId).value = handle.name;
+            const handles = await window.showOpenFilePicker({ multiple: allowMultiple });
+            handles.forEach(h => {
+                target.value += (target.value ? "\n" : "") + h.name;
+            });
         } catch { }
         return;
     }
     const input = document.createElement('input');
     input.type = 'file';
+    if (allowMultiple) input.multiple = true;
     input.onchange = e => {
-        const file = e.target.files[0];
-        if (file) document.getElementById(inputId).value = file.name;
+        Array.from(e.target.files).forEach(file => {
+            target.value += (target.value ? "\n" : "") + file.name;
+        });
     };
     input.click();
 }


### PR DESCRIPTION
## Summary
- allow selecting multiple source files in the web UI
- note browser limitation about absolute paths

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b517c6ad88326a4f13bfcbac90b1a