### PR TITLE
Capture selected directory paths in Web UI

### DIFF
--- a/src/MklinkUi.WebUI/Pages/Index.cshtml
+++ b/src/MklinkUi.WebUI/Pages/Index.cshtml
@@ -41,6 +41,7 @@
                     <input class="form-control" id="destFolder" asp-for="DestinationFolder" />
                     <button type="button" class="btn btn-outline-secondary" onclick="browseFolder('destFolder')"><i class="fa-solid fa-folder-open me-1"></i>Browse</button>
                 </div>
+                <small class="form-text text-muted">Full path support depends on your browser. If only the folder name appears, enter the full path manually.</small>
             </div>
 
             <div class="mb-3" id="folderSource">
@@ -49,6 +50,7 @@
                     <input class="form-control" id="sourcePath" asp-for="SourcePath" />
                     <button type="button" class="btn btn-outline-secondary" onclick="browseFolder('sourcePath')"><i class="fa-solid fa-folder-open me-1"></i>Browse</button>
                 </div>
+                <small class="form-text text-muted">Full path support depends on your browser. If only the folder name appears, enter the full path manually.</small>
             </div>
 
             <div class="mb-3" id="folderDest">
@@ -57,6 +59,7 @@
                     <input class="form-control" id="destPath" asp-for="DestinationPath" />
                     <button type="button" class="btn btn-outline-secondary" onclick="browseFolder('destPath')"><i class="fa-solid fa-folder-open me-1"></i>Browse</button>
                 </div>
+                <small class="form-text text-muted">Full path support depends on your browser. If only the folder name appears, enter the full path manually.</small>
             </div>
 
             <button type="submit" class="btn btn-primary"><i class="fa-solid fa-play me-1"></i>Create Symlink</button>

--- a/src/MklinkUi.WebUI/wwwroot/js/site.js
+++ b/src/MklinkUi.WebUI/wwwroot/js/site.js
@@ -20,7 +20,20 @@ async function browseFolder(inputId) {
     if (window.showDirectoryPicker) {
         try {
             const handle = await window.showDirectoryPicker();
-            document.getElementById(inputId).value = handle.name;
+            let path = handle.name;
+
+            // Non-standard: some browsers expose a full path on the handle
+            if ('path' in handle) {
+                path = handle.path;
+            } else if (handle.resolve && navigator.storage?.getDirectory) {
+                try {
+                    const root = await navigator.storage.getDirectory();
+                    const segments = await root.resolve(handle);
+                    if (segments) path = segments.join('/');
+                } catch { }
+            }
+
+            document.getElementById(inputId).value = path;
         } catch { }
         return;
     }
@@ -29,7 +42,11 @@ async function browseFolder(inputId) {
     input.webkitdirectory = true;
     input.onchange = e => {
         const file = e.target.files[0];
-        if (file) document.getElementById(inputId).value = file.webkitRelativePath.split('/')[0];
+        if (file) {
+            // Prefer the full path when available (e.g., Electron or Chromium-based browsers)
+            const path = file.path || file.webkitRelativePath.split('/')[0];
+            document.getElementById(inputId).value = path;
+        }
     };
     input.click();
 }


### PR DESCRIPTION
## Summary
- Update folder picker to prefer real directory paths when available
- Note browser compatibility and manual entry fallback in index page

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b51af48cc8326b828b111356cae4c