### PR TITLE
Add client-side validation to symlink form

### DIFF
--- a/src/MklinkUi.WebUI/Pages/Index.cshtml
+++ b/src/MklinkUi.WebUI/Pages/Index.cshtml
@@ -17,6 +17,7 @@
         </div>
 
         <form method="post" asp-antiforgery="true">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <div class="mb-3">
                 <label class="form-label" asp-for="LinkType">Symlink Type</label>
                 <div>
@@ -29,10 +30,12 @@
                         <label class="form-check-label" for="linkTypeFolder">Folder</label>
                     </div>
                 </div>
+                <span asp-validation-for="LinkType" class="text-danger"></span>
             </div>
             <div class="mb-3" id="fileInputs">
                 <label class="form-label" asp-for="SourceFilePaths">Source File Paths</label>
                 <textarea class="form-control" asp-for="SourceFilePaths" rows="3"></textarea>
+                <span asp-validation-for="SourceFilePaths" class="text-danger"></span>
             </div>
 
             <div class="mb-3" id="fileDest">
@@ -41,6 +44,7 @@
                     <input class="form-control" id="destFolder" asp-for="DestinationFolder" />
                     <button type="button" class="btn btn-outline-secondary" onclick="browseFolder('destFolder')"><i class="fa-solid fa-folder-open me-1"></i>Browse</button>
                 </div>
+                <span asp-validation-for="DestinationFolder" class="text-danger"></span>
             </div>
 
             <div class="mb-3" id="folderSource">
@@ -49,6 +53,7 @@
                     <input class="form-control" id="sourcePath" asp-for="SourcePath" />
                     <button type="button" class="btn btn-outline-secondary" onclick="browseFolder('sourcePath')"><i class="fa-solid fa-folder-open me-1"></i>Browse</button>
                 </div>
+                <span asp-validation-for="SourcePath" class="text-danger"></span>
             </div>
 
             <div class="mb-3" id="folderDest">
@@ -57,6 +62,7 @@
                     <input class="form-control" id="destPath" asp-for="DestinationPath" />
                     <button type="button" class="btn btn-outline-secondary" onclick="browseFolder('destPath')"><i class="fa-solid fa-folder-open me-1"></i>Browse</button>
                 </div>
+                <span asp-validation-for="DestinationPath" class="text-danger"></span>
             </div>
 
             <button type="submit" class="btn btn-primary"><i class="fa-solid fa-play me-1"></i>Create Symlink</button>
@@ -69,4 +75,8 @@
     <div class="alert @(Model.Success.Value ? "alert-success" : "alert-danger") mt-3" role="alert">
         @Model.Message
     </div>
+}
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
 }


### PR DESCRIPTION
## Summary
- show validation errors via validation summary and per-field messages on symlink creation form
- enable client-side validation scripts

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b5181eefc83268f38a84d41b97254