### PR TITLE
Render detailed symlink results in index page

### DIFF
--- a/src/MklinkUi.WebUI/Pages/Index.cshtml
+++ b/src/MklinkUi.WebUI/Pages/Index.cshtml
@@ -64,9 +64,14 @@
     </div>
 </div>
 
-@if (Model.Success.HasValue)
+@if (Model.Results.Count > 0)
 {
-    <div class="alert @(Model.Success.Value ? "alert-success" : "alert-danger") mt-3" role="alert">
-        @Model.Message
-    </div>
+    <ul class="list-group mt-3">
+        @foreach (var r in Model.Results)
+        {
+            <li class="list-group-item @(r.Success ? "list-group-item-success" : "list-group-item-danger")">
+                @r.Source -> @r.Link: @(r.Success ? "OK" : r.ErrorMessage)
+            </li>
+        }
+    </ul>
 }

--- a/tests/MklinkUi.Tests/IndexModelTests.cs
+++ b/tests/MklinkUi.Tests/IndexModelTests.cs
@@ -25,8 +25,10 @@ public class IndexModelTests
 
         await model.OnPostAsync();
 
-        model.Success.Should().BeFalse();
-        model.Message.Should().Be("One or more file names are invalid.");
+        model.Results.Should().HaveCount(1);
+        var result = model.Results[0];
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Be("One or more file names are invalid.");
     }
 
     [Fact]
@@ -42,8 +44,10 @@ public class IndexModelTests
 
         await model.OnPostAsync();
 
-        model.Success.Should().BeFalse();
-        model.Message.Should().Contain("Source file not found");
+        model.Results.Should().HaveCount(1);
+        var result = model.Results[0];
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Source file not found");
     }
 
     [Fact]
@@ -60,8 +64,10 @@ public class IndexModelTests
 
         await model.OnPostAsync();
 
-        model.Success.Should().BeFalse();
-        model.Message.Should().Be("An unexpected error occurred while creating the symlink.");
+        model.Results.Should().HaveCount(1);
+        var result = model.Results[0];
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Be("An unexpected error occurred while creating the symlink.");
     }
 
     [Fact]
@@ -78,8 +84,10 @@ public class IndexModelTests
 
         await model.OnPostAsync();
 
-        model.Success.Should().BeFalse();
-        model.Message.Should().Be("An unexpected error occurred while creating file symlinks.");
+        model.Results.Should().HaveCount(1);
+        var result = model.Results[0];
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Be("An unexpected error occurred while creating file symlinks.");
     }
 
 


### PR DESCRIPTION
## Summary
- expose `List<SymlinkResultView>` in `IndexModel` for per-link results
- render symlink results as a Bootstrap list group in the index page
- adjust tests to assert on typed result list

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b5192f5508326ae367da1d1019182