### PR TITLE
Disable submit and show spinner during symlink creation

### DIFF
--- a/src/MklinkUi.WebUI/Pages/Index.cshtml
+++ b/src/MklinkUi.WebUI/Pages/Index.cshtml
@@ -59,7 +59,10 @@
                 </div>
             </div>
 
-            <button type="submit" class="btn btn-primary"><i class="fa-solid fa-play me-1"></i>Create Symlink</button>
+            <button type="submit" id="submitButton" class="btn btn-primary">
+                <i class="fa-solid fa-play me-1"></i>Create Symlink
+                <span id="submitSpinner" class="spinner-border spinner-border-sm ms-2 d-none" role="status" aria-hidden="true"></span>
+            </button>
         </form>
     </div>
 </div>

--- a/src/MklinkUi.WebUI/wwwroot/js/site.js
+++ b/src/MklinkUi.WebUI/wwwroot/js/site.js
@@ -46,4 +46,18 @@ window.addEventListener('load', () => {
     document.getElementById('linkTypeFile').addEventListener('change', toggleInputs);
     document.getElementById('linkTypeFolder').addEventListener('change', toggleInputs);
     toggleInputs();
+
+    const submitButton = document.getElementById('submitButton');
+    const spinner = document.getElementById('submitSpinner');
+    if (submitButton && spinner) {
+        const form = submitButton.closest('form');
+        if (form) {
+            form.addEventListener('submit', () => {
+                submitButton.disabled = true;
+                spinner.classList.remove('d-none');
+            });
+        }
+        submitButton.disabled = false;
+        spinner.classList.add('d-none');
+    }
 });


### PR DESCRIPTION
## Summary
- Add ID and spinner to symlink creation button
- Disable submit button and show spinner during form submission

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b51a0e9cc8326a29ceb9987d3ca70