### PR TITLE
Add accessible developer mode status indicator

### DIFF
--- a/src/MklinkUi.WebUI/Pages/Index.cshtml
+++ b/src/MklinkUi.WebUI/Pages/Index.cshtml
@@ -11,7 +11,9 @@
     <div class="card-body">
         <div class="mb-3">
             <label class="form-label">Developer Mode:</label>
-            <span class="fw-bold @(Model.DeveloperModeEnabled ? "text-success" : "text-danger")">
+            <span class="fw-bold @(Model.DeveloperModeEnabled ? "text-success" : "text-danger")"
+                  aria-label='Developer mode @(Model.DeveloperModeEnabled ? "enabled" : "disabled")'>
+                <i class="fa-solid @(Model.DeveloperModeEnabled ? "fa-check text-success" : "fa-times text-danger") me-1" aria-hidden="true"></i>
                 @(Model.DeveloperModeEnabled ? "Enabled" : "Disabled")
             </span>
         </div>


### PR DESCRIPTION
## Summary
- add Font Awesome check/times icon for developer mode status
- label developer mode state for screen readers

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b51897dd0832684c3b09206e7b74a