### PR TITLE
Ensure tests reference global Program type

### DIFF
--- a/tests/MklinkUi.Tests/HealthEndpointTests.cs
+++ b/tests/MklinkUi.Tests/HealthEndpointTests.cs
@@ -7,11 +7,11 @@ using Xunit;
 
 namespace MklinkUi.Tests;
 
-public class HealthEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+public class HealthEndpointTests : IClassFixture<WebApplicationFactory<global::Program>>
 {
-    private readonly WebApplicationFactory<Program> _factory;
+    private readonly WebApplicationFactory<global::Program> _factory;
 
-    public HealthEndpointTests(WebApplicationFactory<Program> factory)
+    public HealthEndpointTests(WebApplicationFactory<global::Program> factory)
     {
         _factory = factory;
     }

--- a/tests/MklinkUi.Tests/PlatformTests.cs
+++ b/tests/MklinkUi.Tests/PlatformTests.cs
@@ -20,7 +20,7 @@ public class PlatformTests
 
         try
         {
-            var entry = typeof(Program).Assembly.EntryPoint!;
+            var entry = typeof(global::Program).Assembly.EntryPoint!;
             Action act = () => entry.Invoke(null, new object[] { Array.Empty<string>() });
 
             act.Should().Throw<TargetInvocationException>()


### PR DESCRIPTION
## Summary
- reference the application's global Program type in tests to avoid protection level issues

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b75a70f3c8326854fec3917b41c65