### PR TITLE
Warn when developer mode status is indeterminate

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The published files are in `src/MklinkUi.WebUI/bin/Release/net8.0/publish`.
 
 ## Limitations and known issues
 - The web UI is minimal and lacks comprehensive error handling.
-- On non-Windows platforms, the developer mode check always reports enabled.
+- If the `MKLINKUI_DEVELOPER_MODE` environment variable is unset or invalid, developer mode is reported as disabled and a warning is logged.
 - Creating symbolic links may require elevated privileges or Windows Developer Mode.
 - Browser file pickers cannot expose absolute file paths, so only file names are captured when selecting files.
 

--- a/tests/MklinkUi.Tests/ServiceRegistrationTests.cs
+++ b/tests/MklinkUi.Tests/ServiceRegistrationTests.cs
@@ -41,11 +41,12 @@ public class ServiceRegistrationTests
     }
 
     [Theory]
-    [InlineData(null, true)]
+    [InlineData(null, false)]
     [InlineData("true", true)]
     [InlineData("1", true)]
     [InlineData("false", false)]
     [InlineData("0", false)]
+    [InlineData("invalid", false)]
     public async Task DefaultDeveloperModeService_Reads_EnvironmentVariable(string? value, bool expected)
     {
         var services = new ServiceCollection();


### PR DESCRIPTION
## Summary
- Log a warning when the `MKLINKUI_DEVELOPER_MODE` environment variable is missing or invalid and treat developer mode as disabled
- Update tests and documentation to reflect the new default behavior

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build src/MklinkUi.Fakes` *(not run: `dotnet` missing)*
- `dotnet build src/MklinkUi.WebUI` *(not run: `dotnet` missing)*
- `dotnet test` *(not run: `dotnet` missing)*

------
https://chatgpt.com/codex/tasks/task_e_689d78fa1b2083269cf9a4f3c2f070d6