### PR TITLE
Add parameterless constructor for DeveloperModeService

### DIFF
--- a/src/MklinkUi.Windows/DeveloperModeService.cs
+++ b/src/MklinkUi.Windows/DeveloperModeService.cs
@@ -8,11 +8,28 @@ namespace MklinkUi.Windows;
 /// <summary>
 /// Windows implementation of <see cref="IDeveloperModeService"/>.
 /// </summary>
-public sealed class DeveloperModeService(ILogger<DeveloperModeService>? logger = null) : IDeveloperModeService
+public sealed class DeveloperModeService : IDeveloperModeService
 {
-    private readonly ILogger<DeveloperModeService> _logger =
-        logger ?? NullLogger<DeveloperModeService>.Instance;
+    private readonly ILogger<DeveloperModeService> _logger;
     private bool? _cached;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeveloperModeService"/> class
+    /// using a <see cref="NullLogger"/> instance.
+    /// </summary>
+    public DeveloperModeService()
+        : this(null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeveloperModeService"/> class.
+    /// </summary>
+    /// <param name="logger">Optional logger instance.</param>
+    public DeveloperModeService(ILogger<DeveloperModeService>? logger)
+    {
+        _logger = logger ?? NullLogger<DeveloperModeService>.Instance;
+    }
 
     public Task<bool> IsEnabledAsync(CancellationToken cancellationToken = default)
     {

--- a/tests/MklinkUi.Windows.Tests/DeveloperModeServiceTests.cs
+++ b/tests/MklinkUi.Windows.Tests/DeveloperModeServiceTests.cs
@@ -16,6 +16,14 @@ public class DeveloperModeServiceTests
     private static extern int RegOverridePredefKey(UIntPtr hKey, IntPtr hNewKey);
 
     [Fact]
+    public void DeveloperModeService_can_be_activated_via_reflection()
+    {
+        var ctor = typeof(DeveloperModeService).GetConstructor(Type.EmptyTypes);
+        ctor.Should().NotBeNull();
+        Activator.CreateInstance(typeof(DeveloperModeService)).Should().NotBeNull();
+    }
+
+    [Fact]
     public async Task IsEnabledAsync_returns_false_on_non_Windows()
     {
         var service = new DeveloperModeService();


### PR DESCRIPTION
## Summary
- add an explicit parameterless ctor for DeveloperModeService so reflection can instantiate it
- test DeveloperModeService activation via reflection

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689d8416e1148326970dcc1b8b720e89