### PR TITLE
feat: support developer mode configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The published files are in `src/MklinkUi.WebUI/bin/Release/net8.0/publish`.
 
 ## Limitations and known issues
 - The web UI is minimal and lacks comprehensive error handling.
-- If the `MKLINKUI_DEVELOPER_MODE` environment variable is unset or invalid, developer mode is reported as disabled and a warning is logged.
+- If the `DeveloperMode` configuration value (or `MKLINKUI_DEVELOPER_MODE` environment variable) is unset or invalid, developer mode is reported as disabled and a warning is logged.
 - Creating symbolic links may require elevated privileges or Windows Developer Mode.
 - Browser file pickers cannot expose absolute file paths, so only file names are captured when selecting files.
 

--- a/src/MklinkUi.WebUI/appsettings.Development.json
+++ b/src/MklinkUi.WebUI/appsettings.Development.json
@@ -5,5 +5,6 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  }
+  },
+  "DeveloperMode": true
 }

--- a/src/MklinkUi.WebUI/appsettings.json
+++ b/src/MklinkUi.WebUI/appsettings.json
@@ -5,5 +5,6 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "DeveloperMode": false
 }

--- a/tests/MklinkUi.Tests/ServiceRegistrationTests.cs
+++ b/tests/MklinkUi.Tests/ServiceRegistrationTests.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using FluentAssertions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using MklinkUi.Core;
 using MklinkUi.WebUI;
@@ -16,6 +18,7 @@ public class ServiceRegistrationTests
         // Arrange
         var services = new ServiceCollection();
         services.AddLogging();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
 
         var originalBase = AppContext.BaseDirectory;
         var tempDir = Directory.CreateTempSubdirectory();
@@ -47,17 +50,24 @@ public class ServiceRegistrationTests
     [InlineData("false", false)]
     [InlineData("0", false)]
     [InlineData("invalid", false)]
-    public async Task DefaultDeveloperModeService_Reads_EnvironmentVariable(string? value, bool expected)
+    public async Task DefaultDeveloperModeService_Reads_Configuration(string? value, bool expected)
     {
         var services = new ServiceCollection();
         services.AddLogging();
 
+        var configBuilder = new ConfigurationBuilder();
+        if (value is not null)
+        {
+            configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["DeveloperMode"] = value
+            });
+        }
+        services.AddSingleton<IConfiguration>(configBuilder.Build());
+
         var originalBase = AppContext.BaseDirectory;
         var tempDir = Directory.CreateTempSubdirectory();
         AppDomain.CurrentDomain.SetData("APP_CONTEXT_BASE_DIRECTORY", tempDir.FullName);
-
-        var originalEnv = Environment.GetEnvironmentVariable("MKLINKUI_DEVELOPER_MODE");
-        Environment.SetEnvironmentVariable("MKLINKUI_DEVELOPER_MODE", value);
 
         try
         {
@@ -71,7 +81,6 @@ public class ServiceRegistrationTests
         {
             AppDomain.CurrentDomain.SetData("APP_CONTEXT_BASE_DIRECTORY", originalBase);
             tempDir.Delete();
-            Environment.SetEnvironmentVariable("MKLINKUI_DEVELOPER_MODE", originalEnv);
         }
     }
 
@@ -80,6 +89,7 @@ public class ServiceRegistrationTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
 
         var originalBase = AppContext.BaseDirectory;
         var tempDir = Directory.CreateTempSubdirectory();
@@ -108,6 +118,7 @@ public class ServiceRegistrationTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
 
         var originalBase = AppContext.BaseDirectory;
         var tempDir = Directory.CreateTempSubdirectory();


### PR DESCRIPTION
## Summary
- read DeveloperMode from configuration instead of only environment variables
- add DeveloperMode to appsettings files
- update tests for configuration-based developer mode

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689d8cbba4c88326bb347f5b35f755fd