### PR TITLE
Use ASPNETCORE_ENVIRONMENT for environment-specific logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ MklinkUI is a small utility for Windows 11 that creates symbolic links and displ
    dotnet test src/MklinkUI.Tests/MklinkUI.Tests.csproj
    ```
 
-Logs are written to `%AppData%/MklinkUI/app.log`.
+Logs are written to `%AppData%/MklinkUI/<Environment>/app.log`, where `<Environment>` comes from the `ASPNETCORE_ENVIRONMENT` variable. The application fails to start if this variable isn't set; `appsettings.json` provides a default of `Development`.
 
 ## Usage
 The application displays the current Developer Mode status. Symlink creation and installer features will be added in future iterations.

--- a/src/MklinkUI.App/App.xaml.cs
+++ b/src/MklinkUI.App/App.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text.Json;
 using System.Windows;
 using Serilog;
 
@@ -10,13 +11,38 @@ public partial class App : Application
     public App()
     {
         var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-        var logDir = Path.Combine(appData, "MklinkUI");
+        var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+
+        if (string.IsNullOrWhiteSpace(environment))
+        {
+            var appSettings = Path.Combine(AppContext.BaseDirectory, "appsettings.json");
+            if (File.Exists(appSettings))
+            {
+                using var stream = File.OpenRead(appSettings);
+                using var doc = JsonDocument.Parse(stream);
+                if (doc.RootElement.TryGetProperty("ASPNETCORE_ENVIRONMENT", out var envProp))
+                {
+                    environment = envProp.GetString();
+                    if (!string.IsNullOrWhiteSpace(environment))
+                    {
+                        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", environment);
+                    }
+                }
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(environment))
+        {
+            throw new InvalidOperationException("ASPNETCORE_ENVIRONMENT is not set. Please set the ASPNETCORE_ENVIRONMENT environment variable.");
+        }
+
+        var logDir = Path.Combine(appData, "MklinkUI", environment);
         Directory.CreateDirectory(logDir);
         Log.Logger = new LoggerConfiguration()
             .WriteTo.File(Path.Combine(logDir, "app.log"))
             .CreateLogger();
 
-        Log.Information("Application starting");
+        Log.Information("Application starting in {Environment} environment", environment);
     }
 
     protected override void OnExit(ExitEventArgs e)

--- a/src/MklinkUI.App/MainViewModel.cs
+++ b/src/MklinkUI.App/MainViewModel.cs
@@ -11,7 +11,13 @@ public class MainViewModel
     {
         // Load the log file content if it exists; otherwise empty string.
         var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-        var logFile = Path.Combine(appData, "MklinkUI", "app.log");
+        var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        if (string.IsNullOrWhiteSpace(environment))
+        {
+            throw new InvalidOperationException("ASPNETCORE_ENVIRONMENT is not set. Please set the ASPNETCORE_ENVIRONMENT environment variable.");
+        }
+
+        var logFile = Path.Combine(appData, "MklinkUI", environment, "app.log");
         LogContent = File.Exists(logFile) ? File.ReadAllText(logFile) : string.Empty;
     }
 }

--- a/src/MklinkUI.App/MklinkUI.App.csproj
+++ b/src/MklinkUI.App/MklinkUI.App.csproj
@@ -13,4 +13,9 @@
   <ItemGroup>
     <ProjectReference Include="..\MklinkUI.Core\MklinkUI.Core.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/MklinkUI.App/appsettings.json
+++ b/src/MklinkUI.App/appsettings.json
@@ -1,0 +1,3 @@
+{
+  "ASPNETCORE_ENVIRONMENT": "Development"
+}


### PR DESCRIPTION
## Summary
- Require `ASPNETCORE_ENVIRONMENT` and load a default from `appsettings.json`
- Fail startup when the environment variable is missing
- Document the environment requirement and per-environment logging

## Testing
- `ASPNETCORE_ENVIRONMENT=Development dotnet test src/MklinkUI.Tests/MklinkUI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_689e206629488326b09c132834981b62