### PR TITLE
refactor: enhance dark theme layout

### DIFF
--- a/src/MklinkUi.WebUI/Pages/Index.cshtml
+++ b/src/MklinkUi.WebUI/Pages/Index.cshtml
@@ -18,9 +18,9 @@
             </span>
         </div>
 
-        <form method="post" asp-antiforgery="true">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-            <div class="mb-3">
+        <form method="post" asp-antiforgery="true" class="d-flex flex-column gap-3">
+            <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+            <div>
                 <label class="form-label" asp-for="LinkType">Symlink Type</label>
                 <div>
                     <div class="form-check form-check-inline">
@@ -35,65 +35,72 @@
                 <span asp-validation-for="LinkType" class="text-danger"></span>
             </div>
 
-            <div class="mb-3" id="fileInputs">
-                <label class="form-label" asp-for="SourceFile">Select a single source file</label>
-                <div class="input-group">
-                    <input class="form-control" id="sourceFile" asp-for="SourceFile" placeholder="C:\\source\\file.txt" />
-                    <button type="button" class="btn btn-outline-secondary" onclick="browseFile('sourceFile', false)"><i class="fa-solid fa-file-import me-1"></i>Browse</button>
+            <div id="fileGroup">
+                <h5 class="mb-3"><i class="fa-solid fa-file me-1"></i>File Link</h5>
+                <div class="mb-3" id="fileInputs">
+                    <label class="form-label" asp-for="SourceFile">Select a single source file</label>
+                    <div class="input-group">
+                        <input class="form-control" id="sourceFile" asp-for="SourceFile" placeholder="C:\\source\\file.txt" />
+                        <button type="button" class="btn btn-outline-secondary" onclick="browseFile('sourceFile', false)"><i class="fa-solid fa-file-import me-1"></i>Browse</button>
+                    </div>
+                    <span asp-validation-for="SourceFile" class="text-danger"></span>
+                    <div class="form-text">Enter the absolute path to the source file.</div>
                 </div>
-                <span asp-validation-for="SourceFile" class="text-danger"></span>
-                <div class="form-text">Enter the absolute path to the source file.</div>
+
+                <div class="mb-3" id="fileDest">
+                    <label class="form-label" asp-for="DestinationFolder">Select destination folder</label>
+                    <div class="input-group">
+                        <input class="form-control" id="destFolderFile" asp-for="DestinationFolder" placeholder="C:\\links" />
+                        <button type="button" class="btn btn-outline-secondary" onclick="browseFolder('destFolderFile')"><i class="fa-solid fa-folder-open me-1"></i>Browse</button>
+                    </div>
+                    <span asp-validation-for="DestinationFolder" class="text-danger"></span>
+                    <small class="form-text text-muted">Full path support depends on your browser. If only the folder name appears, enter the full path manually.</small>
+                </div>
             </div>
 
-            <div class="mb-3" id="fileDest">
-                <label class="form-label" asp-for="DestinationFolder">Select destination folder</label>
-                <div class="input-group">
-                    <input class="form-control" id="destFolderFile" asp-for="DestinationFolder" placeholder="C:\\links" />
-                    <button type="button" class="btn btn-outline-secondary" onclick="browseFolder('destFolderFile')"><i class="fa-solid fa-folder-open me-1"></i>Browse</button>
+            <div id="folderGroup" style="display:none;">
+                <h5 class="mb-3"><i class="fa-solid fa-folder me-1"></i>Folder Link</h5>
+                <div class="mb-3" id="folderSource">
+                    <label class="form-label" asp-for="SourceFolders">Select one or more source folders</label>
+                    <div class="input-group">
+                        <textarea class="form-control" id="sourceFolders" asp-for="SourceFolders" rows="3" placeholder="C:\\source\\folder"></textarea>
+                        <button type="button" class="btn btn-outline-secondary" onclick="browseFolders('sourceFolders')"><i class="fa-solid fa-folder-open me-1"></i>Browse Folders…</button>
+                    </div>
+                    <span asp-validation-for="SourceFolders" class="text-danger"></span>
+                    <div class="form-text">Enter one absolute folder path per line.</div>
                 </div>
-                <span asp-validation-for="DestinationFolder" class="text-danger"></span>
-                <small class="form-text text-muted">Full path support depends on your browser. If only the folder name appears, enter the full path manually.</small>
+
+                <div class="mb-3" id="folderDest">
+                    <label class="form-label" asp-for="DestinationFolder">Select destination folder</label>
+                    <div class="input-group">
+                        <input class="form-control" id="destFolder" asp-for="DestinationFolder" placeholder="C:\\destination" />
+                        <button type="button" class="btn btn-outline-secondary" onclick="browseFolder('destFolder')"><i class="fa-solid fa-folder-open me-1"></i>Browse</button>
+                    </div>
+                    <span asp-validation-for="DestinationFolder" class="text-danger"></span>
+                    <small class="form-text text-muted">Full path support depends on your browser. If only the folder name appears, enter the full path manually.</small>
+                </div>
             </div>
 
-            <div class="mb-3" id="folderSource">
-                <label class="form-label" asp-for="SourceFolders">Select one or more source folders</label>
-                <div class="input-group">
-                    <textarea class="form-control" id="sourceFolders" asp-for="SourceFolders" rows="3" placeholder="C:\\source\\folder"></textarea>
-                    <button type="button" class="btn btn-outline-secondary" onclick="browseFolders('sourceFolders')"><i class="fa-solid fa-folder-open me-1"></i>Browse Folders…</button>
-                </div>
-                <span asp-validation-for="SourceFolders" class="text-danger"></span>
-                <div class="form-text">Enter one absolute folder path per line.</div>
-            </div>
-
-            <div class="mb-3" id="folderDest">
-                <label class="form-label" asp-for="DestinationFolder">Select destination folder</label>
-                <div class="input-group">
-                    <input class="form-control" id="destFolder" asp-for="DestinationFolder" placeholder="C:\\destination" />
-                    <button type="button" class="btn btn-outline-secondary" onclick="browseFolder('destFolder')"><i class="fa-solid fa-folder-open me-1"></i>Browse</button>
-                </div>
-                <span asp-validation-for="DestinationFolder" class="text-danger"></span>
-                <small class="form-text text-muted">Full path support depends on your browser. If only the folder name appears, enter the full path manually.</small>
-            </div>
-
-            <button type="submit" id="submitButton" class="btn btn-primary">
+            <button type="submit" id="submitButton" class="btn btn-primary w-100">
                 <i class="fa-solid fa-play me-1"></i>Create Symlink
                 <span id="submitSpinner" class="spinner-border spinner-border-sm ms-2 d-none" role="status" aria-hidden="true"></span>
             </button>
         </form>
+
+        @if (Model.Results.Count > 0)
+        {
+            <div class="mt-4 d-flex flex-column gap-2">
+                @foreach (var r in Model.Results)
+                {
+                    <div class="alert @(r.Success ? "alert-success" : "alert-danger") d-flex align-items-center" role="alert">
+                        <i class="fa-solid @(r.Success ? "fa-check-circle" : "fa-circle-exclamation") me-2"></i>
+                        <div>@r.Source -> @r.Link: @(r.Success ? "OK" : r.ErrorMessage)</div>
+                    </div>
+                }
+            </div>
+        }
     </div>
 </div>
-
-@if (Model.Results.Count > 0)
-{
-    <ul class="list-group mt-3">
-        @foreach (var r in Model.Results)
-        {
-            <li class="list-group-item @(r.Success ? "list-group-item-success" : "list-group-item-danger")">
-                @r.Source -> @r.Link: @(r.Success ? "OK" : r.ErrorMessage)
-            </li>
-        }
-    </ul>
-}
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/src/MklinkUi.WebUI/Pages/Shared/_Layout.cshtml
+++ b/src/MklinkUi.WebUI/Pages/Shared/_Layout.cshtml
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/MklinkUi.WebUI.styles.css" asp-append-version="true" />
 </head>
-<body>
+<body class="d-flex flex-column min-vh-100 bg-dark text-light">
     <header>
         <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-dark bg-dark border-bottom box-shadow mb-3">
             <div class="container">
@@ -25,14 +25,14 @@
             </div>
         </nav>
     </header>
-    <div class="container flex-fill">
-        <main role="main">
-            @RenderBody()
-        </main>
-    </div>
-
-    <footer class="border-top footer bg-dark text-light">
+    <main role="main" class="flex-fill d-flex align-items-center justify-content-center p-3">
         <div class="container">
+            @RenderBody()
+        </div>
+    </main>
+
+    <footer class="border-top footer bg-dark text-light mt-auto">
+        <div class="container text-center">
             &copy; 2025 - MklinkUi
         </div>
     </footer>

--- a/src/MklinkUi.WebUI/Pages/Shared/_Layout.cshtml.css
+++ b/src/MklinkUi.WebUI/Pages/Shared/_Layout.cshtml.css
@@ -24,9 +24,6 @@ a {
 }
 
 .footer {
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  white-space: nowrap;
   line-height: 60px;
+  white-space: nowrap;
 }

--- a/src/MklinkUi.WebUI/wwwroot/css/site.css
+++ b/src/MklinkUi.WebUI/wwwroot/css/site.css
@@ -21,13 +21,10 @@ body {
   margin-bottom: 60px;
   background-color: #121212;
   color: #f5f5f5;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
 }
 
 main {
-  flex: 1;
+  flex: 1 0 auto;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -35,5 +32,13 @@ main {
 
 .card {
   width: 100%;
-  max-width: 600px;
+  max-width: 800px;
+}
+
+.input-group .btn {
+  min-width: 130px;
+}
+
+.validation-summary-valid {
+  display: none;
 }

--- a/src/MklinkUi.WebUI/wwwroot/js/site.js
+++ b/src/MklinkUi.WebUI/wwwroot/js/site.js
@@ -89,10 +89,8 @@ async function browseFolders(textAreaId) {
 
 function toggleInputs() {
     const isFile = document.getElementById('linkTypeFile').checked;
-    document.getElementById('fileInputs').style.display = isFile ? 'block' : 'none';
-    document.getElementById('fileDest').style.display = isFile ? 'block' : 'none';
-    document.getElementById('folderSource').style.display = isFile ? 'none' : 'block';
-    document.getElementById('folderDest').style.display = isFile ? 'none' : 'block';
+    document.getElementById('fileGroup').style.display = isFile ? 'block' : 'none';
+    document.getElementById('folderGroup').style.display = isFile ? 'none' : 'block';
 }
 
 window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- Center main card and apply flex layout for consistent dark theme
- Style forms and alerts with icons for clear feedback
- Standardize spacing and button widths across inputs

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a27da2ce7883268f740f7e34f0d49e