### PR TITLE
Add configuration and options tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ Run the unit tests:
 dotnet test
 ```
 
+### Testing & Coverage
+
+Collect coverage reports for both test projects:
+
+```bash
+dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat="lcov,cobertura"
+```
+
+The Windows-specific tests in `MklinkUi.Windows.Tests` are automatically skipped on non-Windows hosts.
+
 ## Publishing
 Publish the app for Windows:
 

--- a/tests/MklinkUi.Tests/ConfigurationLayeringTests.cs
+++ b/tests/MklinkUi.Tests/ConfigurationLayeringTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using System.Text;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace MklinkUi.Tests;
+
+public class ConfigurationLayeringTests
+{
+    [Fact]
+    public void Configuration_ShouldUsePrefixedEnvironmentVariables_WhenPresent()
+    {
+        var baseJson = "{\"Server\":{\"DefaultHttpPort\":\"100\"}}";
+        var envJson = "{\"Server\":{\"DefaultHttpPort\":\"200\"}}";
+        using var baseStream = new MemoryStream(Encoding.UTF8.GetBytes(baseJson));
+        using var envStream = new MemoryStream(Encoding.UTF8.GetBytes(envJson));
+
+        Environment.SetEnvironmentVariable("Server__DefaultHttpPort", "300");
+        Environment.SetEnvironmentVariable("MKLINKUI__Server__DefaultHttpPort", "400");
+
+        var config = new ConfigurationBuilder()
+            .AddJsonStream(baseStream)
+            .AddJsonStream(envStream)
+            .AddEnvironmentVariables()
+            .AddEnvironmentVariables("MKLINKUI__")
+            .Build();
+
+        var port = config.GetValue<int>("Server:DefaultHttpPort");
+        port.Should().Be(400);
+
+        Environment.SetEnvironmentVariable("Server__DefaultHttpPort", null);
+        Environment.SetEnvironmentVariable("MKLINKUI__Server__DefaultHttpPort", null);
+    }
+
+    [Theory]
+    [InlineData("DOTNET_ENVIRONMENT")]
+    [InlineData("ASPNETCORE_ENVIRONMENT")]
+    public void EnvironmentVariable_ShouldDriveIsDevelopment_WhenSet(string variable)
+    {
+        Environment.SetEnvironmentVariable(variable, "Development");
+
+        var envName = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT") ??
+                      Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ??
+                      Environments.Production;
+
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = envName });
+        builder.Environment.IsDevelopment().Should().BeTrue();
+
+        Environment.SetEnvironmentVariable(variable, null);
+    }
+}

--- a/tests/MklinkUi.Tests/OptionsTests.cs
+++ b/tests/MklinkUi.Tests/OptionsTests.cs
@@ -47,4 +47,38 @@ public class OptionsTests
         Action act = () => { _ = provider.GetRequiredService<IOptions<ServerOptions>>().Value; };
         act.Should().Throw<OptionsValidationException>();
     }
+
+    [Fact]
+    public void SymlinkOptions_ShouldBindValues_WhenValid()
+    {
+        var dict = new Dictionary<string, string?>
+        {
+            ["Symlink:CollisionPolicy"] = "Overwrite",
+            ["Symlink:BatchMax"] = "10"
+        };
+        var config = new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+        var services = new ServiceCollection();
+        services.AddOptions<SymlinkOptions>().Bind(config.GetSection("Symlink")).ValidateDataAnnotations().ValidateOnStart();
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<SymlinkOptions>>().Value;
+        options.CollisionPolicy.Should().Be(CollisionPolicy.Overwrite);
+        options.BatchMax.Should().Be(10);
+    }
+
+    [Fact]
+    public void UiOptions_ShouldBindValues_WhenValid()
+    {
+        var dict = new Dictionary<string, string?>
+        {
+            ["UI:MaxCardWidth"] = "400",
+            ["UI:EnableDragDrop"] = "false"
+        };
+        var config = new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+        var services = new ServiceCollection();
+        services.AddOptions<UiOptions>().Bind(config.GetSection("UI")).ValidateDataAnnotations().ValidateOnStart();
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<UiOptions>>().Value;
+        options.MaxCardWidth.Should().Be(400);
+        options.EnableDragDrop.Should().BeFalse();
+    }
 }

--- a/tests/MklinkUi.Windows.Tests/MklinkUi.Windows.Tests.csproj
+++ b/tests/MklinkUi.Windows.Tests/MklinkUi.Windows.Tests.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <TargetFramework>net8.0-windows</TargetFramework>
-    <DefineConstants>WINDOWS</DefineConstants>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
@@ -15,9 +16,17 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
     <ProjectReference Include="../../src/MklinkUi.Windows/MklinkUi.Windows.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(OS)' != 'Windows_NT'">
+    <Compile Remove="SymlinkServiceTests.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- expand options binding tests for server, symlink, and UI settings
- add configuration layering test for env var precedence and dev environment detection
- load fake symlink service on non-Windows and isolate Windows-only tests with skippable facts
- document coverage commands and include coverlet in Windows test project

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test /p:CollectCoverage=true`


------
https://chatgpt.com/codex/tasks/task_e_68a2819bad8c8326940d285c37401e18