### PR TITLE
Add structured logging and error codes with correlation IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ The default configuration includes:
 
 Developer mode behaviour is now determined by the standard `DOTNET_ENVIRONMENT` / `ASPNETCORE_ENVIRONMENT` variables; the app treats the `Development` environment as developer mode.
 
+## Logging and diagnostics
+
+MklinkUI uses Serilog for structured logging. Logs are written to `%AppData%/MklinkUi/logs` on Windows or `~/.mklinkui/logs` on other systems with daily rolling files. Each log entry is enriched with machine, process and thread identifiers, application version, environment name and a per-request correlation identifier.
+
+The correlation ID flows through requests via the `X-Correlation-ID` header and is included in any error responses. Include this value when reporting bugs.
+
+| Code | Meaning |
+| --- | --- |
+| E_INVALID_PATH | Provided path was not absolute |
+| E_DEV_MODE_REQUIRED | Developer mode or elevation is required |
+| E_UNEXPECTED | Unexpected server error |
+
+Logging levels are controlled by `Serilog:MinimumLevel` in `appsettings.json` and can be overridden in environment-specific files or via environment variables such as `Serilog__MinimumLevel__Default`.
+
 ## Building
 ### Non-Windows development
 Build the fake services and then the web app:

--- a/src/MklinkUi.Core/ErrorCodes.cs
+++ b/src/MklinkUi.Core/ErrorCodes.cs
@@ -1,0 +1,14 @@
+namespace MklinkUi.Core;
+
+/// <summary>
+/// Well-known error codes for user-visible failures.
+/// </summary>
+public static class ErrorCodes
+{
+    /// <summary>Provided path is not absolute.</summary>
+    public const string InvalidPath = "E_INVALID_PATH";
+    /// <summary>Operation requires developer mode or elevation.</summary>
+    public const string DevModeRequired = "E_DEV_MODE_REQUIRED";
+    /// <summary>Unexpected error.</summary>
+    public const string Unexpected = "E_UNEXPECTED";
+}

--- a/src/MklinkUi.Core/ErrorDetail.cs
+++ b/src/MklinkUi.Core/ErrorDetail.cs
@@ -1,0 +1,10 @@
+namespace MklinkUi.Core;
+
+/// <summary>
+/// Represents a structured error returned to callers.
+/// </summary>
+/// <param name="Code">Stable error identifier.</param>
+/// <param name="Message">User-safe message.</param>
+/// <param name="Details">Optional details without PII.</param>
+/// <param name="CorrelationId">Correlation identifier for diagnostics.</param>
+public record ErrorDetail(string Code, string Message, string? Details = null, string? CorrelationId = null);

--- a/src/MklinkUi.Core/SymlinkResult.cs
+++ b/src/MklinkUi.Core/SymlinkResult.cs
@@ -5,4 +5,5 @@ namespace MklinkUi.Core;
 /// </summary>
 /// <param name="Success">Whether the operation succeeded.</param>
 /// <param name="ErrorMessage">An optional error message.</param>
-public record SymlinkResult(bool Success, string? ErrorMessage = null);
+/// <param name="ErrorCode">Optional error code.</param>
+public record SymlinkResult(bool Success, string? ErrorMessage = null, string? ErrorCode = null);

--- a/src/MklinkUi.WebUI/MklinkUi.WebUI.csproj
+++ b/src/MklinkUi.WebUI/MklinkUi.WebUI.csproj
@@ -23,6 +23,13 @@
       <CopyToPublishDirectory>Always</CopyToPublishDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
+    <PackageReference Include="Serilog.Enrichers.Process" Version="3.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+  </ItemGroup>
 
 </Project>
 

--- a/src/MklinkUi.WebUI/appsettings.Development.json
+++ b/src/MklinkUi.WebUI/appsettings.Development.json
@@ -1,9 +1,8 @@
 {
   "DetailedErrors": true,
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug"
     }
   }
 }

--- a/src/MklinkUi.WebUI/appsettings.json
+++ b/src/MklinkUi.WebUI/appsettings.json
@@ -1,8 +1,11 @@
 {
-  "Logging": {
-    "LogLevel": {
+  "Serilog": {
+    "MinimumLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
     }
   },
   "Kestrel": {

--- a/tests/MklinkUi.Tests/MklinkUi.Tests.csproj
+++ b/tests/MklinkUi.Tests/MklinkUi.Tests.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/MklinkUi.Core/MklinkUi.Core.csproj" />


### PR DESCRIPTION
## Summary
- integrate Serilog with rolling file logs and correlation IDs
- surface structured error codes and details
- log and test path validation failures

## Testing
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a28cb5d318832684bf64da8bb72a81