### PR TITLE
Refactor path validation into shared helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The application runs without containerization and does not expose a health check
 ## Solution structure
 The solution (`MklinkUi.sln`) is composed of several projects, each with a distinct responsibility:
 
-- `src/MklinkUi.Core` – cross-platform abstractions and the `SymlinkManager` coordinator.
+- `src/MklinkUi.Core` – cross-platform abstractions, shared helpers such as `PathHelpers`, and the `SymlinkManager` coordinator.
 - `src/MklinkUi.Windows` – Windows-only services that read the registry and invoke the Win32 `CreateSymbolicLink` API. The project requires the Windows Desktop SDK and is built only on Windows.
 - `src/MklinkUi.Fakes` – stub implementations used for development and tests on non-Windows hosts.
 - `src/MklinkUi.WebUI` – ASP.NET Core front end that loads either `MklinkUi.Windows.dll` or `MklinkUi.Fakes.dll` at runtime.

--- a/src/MklinkUi.Core/PathHelpers.cs
+++ b/src/MklinkUi.Core/PathHelpers.cs
@@ -1,0 +1,26 @@
+namespace MklinkUi.Core;
+
+/// <summary>
+/// Utility helpers for path validation.
+/// </summary>
+public static class PathHelpers
+{
+    /// <summary>
+    /// Returns <c>true</c> when all provided paths are non-empty and fully qualified.
+    /// </summary>
+    public static bool AreFullyQualified(params string?[] paths)
+    {
+        foreach (var path in paths)
+        {
+            if (!IsFullyQualified(path))
+                return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when the given path is non-empty and fully qualified.
+    /// </summary>
+    public static bool IsFullyQualified(string? path) =>
+        !string.IsNullOrWhiteSpace(path) && Path.IsPathFullyQualified(path);
+}

--- a/src/MklinkUi.Core/SymlinkManager.cs
+++ b/src/MklinkUi.Core/SymlinkManager.cs
@@ -24,7 +24,7 @@ public sealed class SymlinkManager(
         ArgumentException.ThrowIfNullOrWhiteSpace(sourceFile);
         ArgumentException.ThrowIfNullOrWhiteSpace(destinationFolder);
 
-        if (!Path.IsPathFullyQualified(sourceFile) || !Path.IsPathFullyQualified(destinationFolder))
+        if (!PathHelpers.AreFullyQualified(sourceFile, destinationFolder))
         {
             using var scope = logger.BeginScope(new Dictionary<string, object> { ["ErrorCode"] = ErrorCodes.InvalidPath });
             logger.LogWarning("Paths must be absolute. Source: {SourceFile}, Destination: {DestinationFolder}", sourceFile, destinationFolder);
@@ -62,8 +62,8 @@ public sealed class SymlinkManager(
 
         var sources = sourceFolders.ToList();
 
-        if (sources.Any(s => string.IsNullOrWhiteSpace(s) || !Path.IsPathFullyQualified(s)) ||
-            !Path.IsPathFullyQualified(destinationFolder))
+        if (sources.Any(s => !PathHelpers.IsFullyQualified(s)) ||
+            !PathHelpers.IsFullyQualified(destinationFolder))
         {
             using var scope = logger.BeginScope(new Dictionary<string, object> { ["ErrorCode"] = ErrorCodes.InvalidPath });
             logger.LogWarning("Paths must be absolute. Destination: {DestinationFolder}", destinationFolder);

--- a/src/MklinkUi.Fakes/FakeSymlinkService.cs
+++ b/src/MklinkUi.Fakes/FakeSymlinkService.cs
@@ -19,7 +19,7 @@ public sealed class FakeSymlinkService : ISymlinkService
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(sourceFile);
         ArgumentException.ThrowIfNullOrWhiteSpace(destinationFolder);
-        if (!Path.IsPathFullyQualified(sourceFile) || !Path.IsPathFullyQualified(destinationFolder))
+        if (!PathHelpers.AreFullyQualified(sourceFile, destinationFolder))
             throw new ArgumentException("Paths must be absolute.");
 
         var link = Path.Combine(destinationFolder, Path.GetFileName(sourceFile));
@@ -35,14 +35,14 @@ public sealed class FakeSymlinkService : ISymlinkService
     {
         ArgumentNullException.ThrowIfNull(sourceFolders);
         ArgumentException.ThrowIfNullOrWhiteSpace(destinationFolder);
-        if (!Path.IsPathFullyQualified(destinationFolder))
+        if (!PathHelpers.IsFullyQualified(destinationFolder))
             throw new ArgumentException("Paths must be absolute.");
 
         var results = new List<SymlinkResult>();
         foreach (var source in sourceFolders)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (string.IsNullOrWhiteSpace(source) || !Path.IsPathFullyQualified(source))
+            if (!PathHelpers.IsFullyQualified(source))
             {
                 results.Add(new SymlinkResult(false, "Invalid source."));
                 continue;

--- a/src/MklinkUi.WebUI/Pages/Index.cshtml.cs
+++ b/src/MklinkUi.WebUI/Pages/Index.cshtml.cs
@@ -47,7 +47,7 @@ public sealed class IndexModel(
                 return Page();
             }
 
-            if (!Path.IsPathFullyQualified(SourceFile) || !Path.IsPathFullyQualified(DestinationFolder))
+            if (!PathHelpers.AreFullyQualified(SourceFile, DestinationFolder))
             {
                 Results.Add(new SymlinkResultView(SourceFile, DestinationFolder, false,
                     "Paths must be absolute."));
@@ -89,7 +89,7 @@ public sealed class IndexModel(
             return Page();
         }
 
-        if (folders.Any(f => !Path.IsPathFullyQualified(f)) || !Path.IsPathFullyQualified(DestinationFolder))
+        if (folders.Any(f => !PathHelpers.IsFullyQualified(f)) || !PathHelpers.IsFullyQualified(DestinationFolder))
         {
             Results.Add(new SymlinkResultView(string.Empty, DestinationFolder, false,
                 "Paths must be absolute."));

--- a/src/MklinkUi.WebUI/ServiceRegistration.cs
+++ b/src/MklinkUi.WebUI/ServiceRegistration.cs
@@ -72,7 +72,7 @@ public static class ServiceRegistration
             ArgumentException.ThrowIfNullOrWhiteSpace(destinationFolder);
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (!Path.IsPathFullyQualified(sourceFile) || !Path.IsPathFullyQualified(destinationFolder))
+            if (!PathHelpers.AreFullyQualified(sourceFile, destinationFolder))
                 throw new ArgumentException("Paths must be absolute.");
 
             var link = Path.Combine(destinationFolder, Path.GetFileName(sourceFile));
@@ -107,8 +107,7 @@ public static class ServiceRegistration
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if (string.IsNullOrWhiteSpace(source) || !Path.IsPathFullyQualified(source) ||
-                    !Path.IsPathFullyQualified(destinationFolder))
+                if (!PathHelpers.AreFullyQualified(source, destinationFolder))
                 {
                     results.Add(new SymlinkResult(false, "Invalid source."));
                     continue;

--- a/src/MklinkUi.Windows/SymlinkService.cs
+++ b/src/MklinkUi.Windows/SymlinkService.cs
@@ -25,7 +25,7 @@ public sealed class SymlinkService : ISymlinkService
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(sourceFile);
         ArgumentException.ThrowIfNullOrWhiteSpace(destinationFolder);
-        if (!Path.IsPathFullyQualified(sourceFile) || !Path.IsPathFullyQualified(destinationFolder))
+        if (!PathHelpers.AreFullyQualified(sourceFile, destinationFolder))
             throw new ArgumentException("Paths must be absolute.");
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -51,14 +51,14 @@ public sealed class SymlinkService : ISymlinkService
     {
         ArgumentNullException.ThrowIfNull(sourceFolders);
         ArgumentException.ThrowIfNullOrWhiteSpace(destinationFolder);
-        if (!Path.IsPathFullyQualified(destinationFolder))
+        if (!PathHelpers.IsFullyQualified(destinationFolder))
             throw new ArgumentException("Paths must be absolute.");
 
         var results = new List<SymlinkResult>();
         foreach (var source in sourceFolders)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (string.IsNullOrWhiteSpace(source) || !Path.IsPathFullyQualified(source))
+            if (!PathHelpers.IsFullyQualified(source))
             {
                 results.Add(new SymlinkResult(false, "Invalid source."));
                 continue;


### PR DESCRIPTION
## Summary
- extract PathHelpers to centralize absolute path checks
- update services and web UI to use shared path validation
- note shared helpers in README

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`
- `dotnet format`

------
https://chatgpt.com/codex/tasks/task_e_68a295603a5483269586df5e59ff5f2c