### PR TITLE
Require configuration for server ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ MklinkUI is a small web-based utility that creates file or directory symbolic li
 
 The application runs without containerization and does not expose a health check endpoint.
 
+## Prerequisites
+- [.NET 8 SDK](https://dotnet.microsoft.com/)
+- [Visual Studio 2022](https://visualstudio.microsoft.com/) 17.8 or later (for IDE builds)
+
 ## Solution structure
 The solution (`MklinkUi.sln`) is composed of several projects, each with a distinct responsibility:
 

--- a/src/MklinkUi.WebUI/Program.cs
+++ b/src/MklinkUi.WebUI/Program.cs
@@ -78,7 +78,7 @@ builder.Services.AddOptions<PathOptions>()
         }
     });
 
-var serverOpts = builder.Configuration.GetSection("Server").Get<ServerOptions>() ?? new();
+var serverOpts = builder.Configuration.GetRequiredSection("Server").Get<ServerOptions>()!;
 var range = ParseRange(serverOpts.PreferredPortRange);
 var httpPort = FindAvailablePort(serverOpts.DefaultHttpPort, range);
 var httpsPort = FindAvailablePort(serverOpts.DefaultHttpsPort, range);

--- a/src/MklinkUi.WebUI/ServerOptions.cs
+++ b/src/MklinkUi.WebUI/ServerOptions.cs
@@ -5,11 +5,11 @@ namespace MklinkUi.WebUI;
 public sealed class ServerOptions
 {
     [RegularExpression("^\\d+-\\d+$")]
-    public string PreferredPortRange { get; set; } = "5280-5299";
+    public required string PreferredPortRange { get; set; }
 
     [Range(1, 65535)]
-    public int DefaultHttpPort { get; set; } = 5280;
+    public required int DefaultHttpPort { get; set; }
 
     [Range(1, 65535)]
-    public int DefaultHttpsPort { get; set; } = 5281;
+    public required int DefaultHttpsPort { get; set; }
 }

--- a/tests/MklinkUi.Tests/IndexViewTests.cs
+++ b/tests/MklinkUi.Tests/IndexViewTests.cs
@@ -9,9 +9,14 @@ public class IndexViewTests
     [Fact]
     public void IndexView_includes_antiforgery_attribute()
     {
-        var path = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory,
-            "..", "..", "..", "..", "..", "src", "MklinkUi.WebUI", "Pages", "Index.cshtml"));
-        File.Exists(path).Should().BeTrue();
+        var dir = AppContext.BaseDirectory;
+        while (!File.Exists(Path.Combine(dir, "src", "MklinkUi.WebUI", "Pages", "Index.cshtml")))
+        {
+            var parent = Directory.GetParent(dir) ?? throw new InvalidOperationException("Could not locate repository root.");
+            dir = parent.FullName;
+        }
+
+        var path = Path.Combine(dir, "src", "MklinkUi.WebUI", "Pages", "Index.cshtml");
         var content = File.ReadAllText(path);
         content.Should().Contain("asp-antiforgery=\"true\"");
     }


### PR DESCRIPTION
## Summary
- remove hard-coded server port defaults and require explicit configuration
- document .NET 8 and Visual Studio 2022 prerequisites
- stabilize antiforgery view test by dynamically locating the repository root

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a2986c28588326b388f9ad95ecadda