### PR TITLE
Handle cancellation and missing source in CreateFileLinkAsync

### DIFF
--- a/src/MklinkUi.Core/ErrorCodes.cs
+++ b/src/MklinkUi.Core/ErrorCodes.cs
@@ -11,4 +11,6 @@ public static class ErrorCodes
     public const string DevModeRequired = "E_DEV_MODE_REQUIRED";
     /// <summary>Unexpected error.</summary>
     public const string Unexpected = "E_UNEXPECTED";
+    /// <summary>Specified file or directory was not found.</summary>
+    public const string PathNotFound = "E_PATH_NOT_FOUND";
 }


### PR DESCRIPTION
## Summary
- ensure CreateFileLinkAsync checks cancellation before validating paths
- return PathNotFound failure when source or destination is missing
- add PathNotFound error code and log link outcomes

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Windows`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a2cb2f17b4832682be29bf5f78aba6