### PR TITLE
Normalize path validation and align symlink service checks

### DIFF
--- a/src/MklinkUi.Core/PathValidation.cs
+++ b/src/MklinkUi.Core/PathValidation.cs
@@ -17,14 +17,14 @@ public static class PathValidation
     /// <summary>
     /// Ensures the provided path is absolute and returns the normalized value.
     /// </summary>
-    public static string EnsureAbsolute(string path)
+    public static string EnsureAbsolute(string path, string paramName)
     {
         if (string.IsNullOrWhiteSpace(path))
-            throw new ArgumentException("Paths must be absolute.");
+            throw new ArgumentException("Paths must be absolute.", paramName);
 
         var full = Path.GetFullPath(path);
         if (!Path.IsPathFullyQualified(full))
-            throw new ArgumentException("Paths must be absolute.");
+            throw new ArgumentException("Paths must be absolute.", paramName);
 
         return full;
     }


### PR DESCRIPTION
## Summary
- Centralize absolute path normalization with parameter-aware `PathValidation.EnsureAbsolute`
- Rework fake symlink service to normalize paths, simulate collisions, and respect cancellation & developer mode
- Align Windows symlink service ordering, collision handling, and path normalization

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.Windows`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a2d4445e0c83269d9a762084631bc6