### PR TITLE
Expose normalized link paths in symlink results

### DIFF
--- a/src/MklinkUi.Core/SymlinkResult.cs
+++ b/src/MklinkUi.Core/SymlinkResult.cs
@@ -6,4 +6,5 @@ namespace MklinkUi.Core;
 /// <param name="Success">Whether the operation succeeded.</param>
 /// <param name="ErrorMessage">An optional error message.</param>
 /// <param name="ErrorCode">Optional error code.</param>
-public record SymlinkResult(bool Success, string? ErrorMessage = null, string? ErrorCode = null);
+/// <param name="LinkPath">The created link path when successful.</param>
+public record SymlinkResult(bool Success, string? ErrorMessage = null, string? ErrorCode = null, string? LinkPath = null);

--- a/src/MklinkUi.Fakes/FakeSymlinkService.cs
+++ b/src/MklinkUi.Fakes/FakeSymlinkService.cs
@@ -51,7 +51,7 @@ public sealed class FakeSymlinkService : ISymlinkService
 
         _links.Add(linkPath);
         _created.Add((linkPath, sourceFile));
-        return new SymlinkResult(true);
+        return new SymlinkResult(true, LinkPath: linkPath);
     }
 
     public async Task<IReadOnlyList<SymlinkResult>> CreateDirectoryLinksAsync(IReadOnlyList<string> sourceFolders,
@@ -98,7 +98,7 @@ public sealed class FakeSymlinkService : ISymlinkService
 
             _links.Add(linkPath);
             _created.Add((linkPath, absSource));
-            results.Add(new SymlinkResult(true));
+            results.Add(new SymlinkResult(true, LinkPath: linkPath));
         }
 
         return results;

--- a/src/MklinkUi.WebUI/ServiceRegistration.cs
+++ b/src/MklinkUi.WebUI/ServiceRegistration.cs
@@ -80,8 +80,9 @@ public static class ServiceRegistration
             try
             {
                 var targetLink = HandleCollision(link, isDirectory: false);
+                targetLink = Path.GetFullPath(targetLink);
                 File.CreateSymbolicLink(targetLink, sourceFile);
-                return Task.FromResult(new SymlinkResult(true));
+                return Task.FromResult(new SymlinkResult(true, LinkPath: targetLink));
             }
             catch (IOException ex) when (ex.Message == "Link already exists.")
             {
@@ -118,8 +119,9 @@ public static class ServiceRegistration
                 try
                 {
                     var targetLink = HandleCollision(link, isDirectory: true);
+                    targetLink = Path.GetFullPath(targetLink);
                     Directory.CreateSymbolicLink(targetLink, source);
-                    results.Add(new SymlinkResult(true));
+                    results.Add(new SymlinkResult(true, LinkPath: targetLink));
                 }
                 catch (IOException ex) when (ex.Message == "Link already exists.")
                 {

--- a/src/MklinkUi.Windows/SymlinkService.cs
+++ b/src/MklinkUi.Windows/SymlinkService.cs
@@ -58,7 +58,7 @@ public sealed class SymlinkService : ISymlinkService
         {
             File.CreateSymbolicLink(link, sourceFile);
             _logger.LogInformation("Created file symlink: {Link} -> {Source}", link, sourceFile);
-            return new SymlinkResult(true);
+            return new SymlinkResult(true, LinkPath: link);
         }
         catch (Exception ex)
         {
@@ -110,7 +110,7 @@ public sealed class SymlinkService : ISymlinkService
             try
             {
                 Directory.CreateSymbolicLink(link, absSource);
-                results.Add(new SymlinkResult(true));
+                results.Add(new SymlinkResult(true, LinkPath: link));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- extend `SymlinkResult` with `LinkPath`
- propagate normalized link paths from fake, Windows, and default symlink services

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.Windows`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a2d743f9e08326bfc16dca15d8d42c