### PR TITLE
Normalize path detection across platforms

### DIFF
--- a/src/MklinkUi.Core/PathValidation.cs
+++ b/src/MklinkUi.Core/PathValidation.cs
@@ -12,20 +12,29 @@ public static class PathValidation
     /// Determines whether the provided path resolves to an absolute path.
     /// </summary>
     public static bool IsAbsolutePath(string? path)
-        => !string.IsNullOrWhiteSpace(path) && Path.IsPathFullyQualified(path);
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return false;
+        if (Path.IsPathFullyQualified(path))
+            return true;
+        var first = path[0];
+        return first == Path.DirectorySeparatorChar || first == Path.AltDirectorySeparatorChar;
+    }
 
     /// <summary>
     /// Ensures the provided path is absolute and returns the normalized value.
     /// </summary>
     public static string EnsureAbsolute(string path, string paramName)
     {
-        if (string.IsNullOrWhiteSpace(path))
+        if (!IsAbsolutePath(path))
             throw new ArgumentException("Paths must be absolute.", paramName);
-
-        var full = Path.GetFullPath(path);
-        if (!Path.IsPathFullyQualified(full))
+        try
+        {
+            return Path.GetFullPath(path);
+        }
+        catch (Exception)
+        {
             throw new ArgumentException("Paths must be absolute.", paramName);
-
-        return full;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- treat rooted paths as absolute so cross-platform slashes don't trigger false invalid-path errors
- normalize and validate paths using the revised helper

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.Windows`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a2dd34571c8326bb43cc2ea531847e