### PR TITLE
Enable multi-folder selection and handle folder picker cancel

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The published files are in `src/MklinkUi.WebUI/bin/Release/net8.0/publish`.
 The dark-themed web interface centers its main card on screen for common desktop resolutions. Two link modes are available:
 
 - **File → File** – select a single source file and a destination folder. A link with the same file name is created inside the destination folder.
-- **Folder → Folder** – select one or more source folders and a destination folder. Each selected folder is linked into the destination folder using its original name.
+ - **Folder → Folder** – select one or more source folders and a destination folder. The picker allows multi-selection; cancelling it simply closes the dialog. Each selected folder is linked into the destination folder using its original name.
 
 All paths must be provided as absolute paths; relative paths are rejected by the UI and services.
 

--- a/src/MklinkUi.WebUI/Pages/Index.cshtml
+++ b/src/MklinkUi.WebUI/Pages/Index.cshtml
@@ -63,11 +63,11 @@
                 <div class="mb-3" id="folderSource">
                     <label class="form-label" asp-for="SourceFolders">Select one or more source folders</label>
                     <div class="input-group">
-                        <textarea class="form-control" id="sourceFolders" asp-for="SourceFolders" rows="3" placeholder="C:\\source\\folder"></textarea>
+                        <textarea class="form-control" id="sourceFolders" asp-for="SourceFolders" rows="5" placeholder="C:\\source\\folder"></textarea>
                         <button type="button" class="btn btn-outline-secondary" onclick="browseFolders('sourceFolders')"><i class="fa-solid fa-folder-open me-1"></i>Browse Folders…</button>
                     </div>
                     <span asp-validation-for="SourceFolders" class="text-danger"></span>
-                    <div class="form-text">Enter one absolute folder path per line.</div>
+                    <div class="form-text">Enter one absolute folder path per line or use Browse to select multiple folders.</div>
                 </div>
 
                 <div class="mb-3" id="folderDest">

--- a/src/MklinkUi.WebUI/Pages/Index.cshtml.cs
+++ b/src/MklinkUi.WebUI/Pages/Index.cshtml.cs
@@ -82,7 +82,12 @@ public sealed class IndexModel(
             .Split(NewLineSeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .ToList();
 
-        if (folders.Count == 0 || string.IsNullOrWhiteSpace(DestinationFolder))
+        if (folders.Count == 0)
+        {
+            return Page();
+        }
+
+        if (string.IsNullOrWhiteSpace(DestinationFolder))
         {
             Results.Add(new SymlinkResultView(string.Empty, DestinationFolder, false,
                 "Select at least one source folder and a destination folder."));

--- a/src/MklinkUi.WebUI/wwwroot/js/site.js
+++ b/src/MklinkUi.WebUI/wwwroot/js/site.js
@@ -57,34 +57,33 @@ async function browseFolder(inputId) {
     input.click();
 }
 
+function appendFolders(target, files) {
+    const dirs = new Set();
+    Array.from(files).forEach(f => {
+        const path = (f.path || f.webkitRelativePath.split('/')[0]).replaceAll('\\', '/');
+        dirs.add(path);
+    });
+    if (dirs.size === 0) return;
+    const existing = new Set(target.value.split(/\r?\n/).filter(Boolean));
+    dirs.forEach(d => {
+        if (!existing.has(d)) {
+            target.value += (target.value ? "\n" : "") + d;
+        }
+    });
+}
+
 async function browseFolders(textAreaId) {
     const target = document.getElementById(textAreaId);
-    if (window.showDirectoryPicker) {
-        try {
-            const handle = await window.showDirectoryPicker();
-            let path = handle.name;
-            if ('path' in handle) {
-                path = handle.path;
-            }
-            target.value += (target.value ? "\n" : "") + path;
-        } catch { }
-        return;
-    }
     const input = document.createElement('input');
     input.type = 'file';
     input.webkitdirectory = true;
     input.multiple = true;
-    input.onchange = e => {
-        const dirs = new Set();
-        Array.from(e.target.files).forEach(f => {
-            const path = f.path || f.webkitRelativePath.split('/')[0];
-            dirs.add(path);
-        });
-        dirs.forEach(d => {
-            target.value += (target.value ? "\n" : "") + d;
-        });
-    };
+    input.onchange = e => appendFolders(target, e.target.files);
     input.click();
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = { appendFolders };
 }
 
 function toggleInputs() {
@@ -93,22 +92,24 @@ function toggleInputs() {
     document.getElementById('folderGroup').style.display = isFile ? 'none' : 'block';
 }
 
-window.addEventListener('load', () => {
-    document.getElementById('linkTypeFile').addEventListener('change', toggleInputs);
-    document.getElementById('linkTypeFolder').addEventListener('change', toggleInputs);
-    toggleInputs();
+if (typeof window !== 'undefined') {
+    window.addEventListener('load', () => {
+        document.getElementById('linkTypeFile').addEventListener('change', toggleInputs);
+        document.getElementById('linkTypeFolder').addEventListener('change', toggleInputs);
+        toggleInputs();
 
-    const submitButton = document.getElementById('submitButton');
-    const spinner = document.getElementById('submitSpinner');
-    if (submitButton && spinner) {
-        const form = submitButton.closest('form');
-        if (form) {
-            form.addEventListener('submit', () => {
-                submitButton.disabled = true;
-                spinner.classList.remove('d-none');
-            });
+        const submitButton = document.getElementById('submitButton');
+        const spinner = document.getElementById('submitSpinner');
+        if (submitButton && spinner) {
+            const form = submitButton.closest('form');
+            if (form) {
+                form.addEventListener('submit', () => {
+                    submitButton.disabled = true;
+                    spinner.classList.remove('d-none');
+                });
+            }
+            submitButton.disabled = false;
+            spinner.classList.add('d-none');
         }
-        submitButton.disabled = false;
-        spinner.classList.add('d-none');
-    }
-});
+    });
+}

--- a/tests/MklinkUi.Tests/FolderSelectionTests.cs
+++ b/tests/MklinkUi.Tests/FolderSelectionTests.cs
@@ -1,0 +1,32 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using MklinkUi.Core;
+using MklinkUi.Fakes;
+using MklinkUi.WebUI.Pages;
+using Xunit;
+
+namespace MklinkUi.Tests;
+
+public class FolderSelectionTests
+{
+    [Fact]
+    public async Task OnPostAsync_no_source_folders_is_noop()
+    {
+        var env = new FakeHostEnvironment();
+        var service = new FakeSymlinkService();
+        var manager = new SymlinkManager(env, service, Options.Create(new SymlinkOptions()), NullLogger<SymlinkManager>.Instance);
+        var model = new IndexModel(manager, env, NullLogger<IndexModel>.Instance)
+        {
+            LinkType = "Folder",
+            SourceFolders = string.Empty,
+            DestinationFolder = string.Empty
+        };
+
+        var result = await model.OnPostAsync();
+
+        result.Should().NotBeNull();
+        model.Results.Should().BeEmpty();
+    }
+}

--- a/tests/client/appendFolders.test.js
+++ b/tests/client/appendFolders.test.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+const { appendFolders } = require('../../src/MklinkUi.WebUI/wwwroot/js/site.js');
+
+const target = { value: 'C:/existing' };
+appendFolders(target, []);
+assert.strictEqual(target.value, 'C:/existing');
+
+console.log('appendFolders cancel test passed');


### PR DESCRIPTION
## Summary
- allow choosing multiple source folders at once and de-dupe/preview them
- treat empty folder selection as a no-op on the server
- document and test folder picker cancel behavior

## Testing
- `node tests/client/appendFolders.test.js`
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a2e33dfeec8326ae02efb79912beaf