### PR TITLE
Fix file picker selection and folder browsing options

### DIFF
--- a/src/MklinkUi.WebUI/Pages/Index.cshtml
+++ b/src/MklinkUi.WebUI/Pages/Index.cshtml
@@ -40,8 +40,8 @@
                 <div class="mb-3" id="fileInputs">
                     <label class="form-label" asp-for="SourceFile">Select a single source file</label>
                     <div class="input-group">
-                        <input class="form-control" id="sourceFile" asp-for="SourceFile" placeholder="C:\\source\\file.txt" />
-                        <button type="button" class="btn btn-outline-secondary" onclick="browseFile('sourceFile', false)"><i class="fa-solid fa-file-import me-1"></i>Browse</button>
+                        <input class="form-control" id="sourceFile" asp-for="SourceFile" placeholder="C:\source\file.txt" />
+                        <button type="button" class="btn btn-outline-secondary" onclick="browseFile('sourceFile')"><i class="fa-solid fa-file-import me-1"></i>Browse</button>
                     </div>
                     <span asp-validation-for="SourceFile" class="text-danger"></span>
                     <div class="form-text">Enter the absolute path to the source file.</div>
@@ -50,7 +50,7 @@
                 <div class="mb-3" id="fileDest">
                     <label class="form-label" asp-for="DestinationFolder">Select destination folder</label>
                     <div class="input-group">
-                        <input class="form-control" id="destFolderFile" asp-for="DestinationFolder" placeholder="C:\\links" />
+                        <input class="form-control" id="destFolderFile" asp-for="DestinationFolder" placeholder="C:\links" />
                         <button type="button" class="btn btn-outline-secondary" onclick="browseFolder('destFolderFile')"><i class="fa-solid fa-folder-open me-1"></i>Browse</button>
                     </div>
                     <span asp-validation-for="DestinationFolder" class="text-danger"></span>
@@ -63,8 +63,8 @@
                 <div class="mb-3" id="folderSource">
                     <label class="form-label" asp-for="SourceFolders">Select one or more source folders</label>
                     <div class="input-group">
-                        <textarea class="form-control" id="sourceFolders" asp-for="SourceFolders" rows="5" placeholder="C:\\source\\folder"></textarea>
-                        <button type="button" class="btn btn-outline-secondary" onclick="browseFolders('sourceFolders')"><i class="fa-solid fa-folder-open me-1"></i>Browse Folders…</button>
+                        <textarea class="form-control" id="sourceFolders" asp-for="SourceFolders" rows="5" placeholder="C:\source\folder"></textarea>
+                        <button type="button" class="btn btn-outline-secondary" onclick="browseFolder('sourceFolders', true)"><i class="fa-solid fa-folder-open me-1"></i>Browse Folders…</button>
                     </div>
                     <span asp-validation-for="SourceFolders" class="text-danger"></span>
                     <div class="form-text">Enter one absolute folder path per line or use Browse to select multiple folders.</div>
@@ -73,7 +73,7 @@
                 <div class="mb-3" id="folderDest">
                     <label class="form-label" asp-for="DestinationFolder">Select destination folder</label>
                     <div class="input-group">
-                        <input class="form-control" id="destFolder" asp-for="DestinationFolder" placeholder="C:\\destination" />
+                        <input class="form-control" id="destFolder" asp-for="DestinationFolder" placeholder="C:\destination" />
                         <button type="button" class="btn btn-outline-secondary" onclick="browseFolder('destFolder')"><i class="fa-solid fa-folder-open me-1"></i>Browse</button>
                     </div>
                     <span asp-validation-for="DestinationFolder" class="text-danger"></span>

--- a/src/MklinkUi.WebUI/wwwroot/js/site.js
+++ b/src/MklinkUi.WebUI/wwwroot/js/site.js
@@ -1,28 +1,36 @@
 // File and folder browsers
 // Browsers limit access to absolute file paths for security, so only file names are available.
-async function browseFile(inputId, allowMultiple = false) {
+async function browseFile(inputId) {
     const target = document.getElementById(inputId);
     if (window.showOpenFilePicker) {
         try {
-            const handles = await window.showOpenFilePicker({ multiple: allowMultiple });
-            handles.forEach(h => {
-                target.value += (target.value ? "\n" : "") + h.name;
-            });
+            const [handle] = await window.showOpenFilePicker({ multiple: false });
+            if (handle) target.value = handle.name;
         } catch { }
         return;
     }
     const input = document.createElement('input');
     input.type = 'file';
-    if (allowMultiple) input.multiple = true;
     input.onchange = e => {
-        Array.from(e.target.files).forEach(file => {
-            target.value += (target.value ? "\n" : "") + file.name;
-        });
+        const file = e.target.files[0];
+        if (file) target.value = file.name;
     };
     input.click();
 }
 
-async function browseFolder(inputId) {
+async function browseFolder(inputId, allowMultiple = false) {
+    const target = document.getElementById(inputId);
+
+    if (allowMultiple) {
+        const input = document.createElement('input');
+        input.type = 'file';
+        input.webkitdirectory = true;
+        input.multiple = true;
+        input.onchange = e => appendFolders(target, e.target.files);
+        input.click();
+        return;
+    }
+
     if (window.showDirectoryPicker) {
         try {
             const handle = await window.showDirectoryPicker();
@@ -39,7 +47,7 @@ async function browseFolder(inputId) {
                 } catch { }
             }
 
-            document.getElementById(inputId).value = path;
+            target.value = path;
         } catch { }
         return;
     }
@@ -51,7 +59,7 @@ async function browseFolder(inputId) {
         if (file) {
             // Prefer the full path when available (e.g., Electron or Chromium-based browsers)
             const path = file.path || file.webkitRelativePath.split('/')[0];
-            document.getElementById(inputId).value = path;
+            target.value = path;
         }
     };
     input.click();
@@ -70,16 +78,6 @@ function appendFolders(target, files) {
             target.value += (target.value ? "\n" : "") + d;
         }
     });
-}
-
-async function browseFolders(textAreaId) {
-    const target = document.getElementById(textAreaId);
-    const input = document.createElement('input');
-    input.type = 'file';
-    input.webkitdirectory = true;
-    input.multiple = true;
-    input.onchange = e => appendFolders(target, e.target.files);
-    input.click();
 }
 
 if (typeof module !== 'undefined') {


### PR DESCRIPTION
## Summary
- Ensure file browse only selects a single file
- Allow browseFolder to collect multiple folders when requested
- Clean placeholder paths for Windows examples

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`
- `node tests/client/appendFolders.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a3fd9ed1ec832696305d1deabc2145