### PR TITLE
Use webkitdirectory input as default folder picker

### DIFF
--- a/tests/client/appendFolders.test.js
+++ b/tests/client/appendFolders.test.js
@@ -5,4 +5,10 @@ const target = { value: 'C:/existing' };
 appendFolders(target, []);
 assert.strictEqual(target.value, 'C:/existing');
 
-console.log('appendFolders cancel test passed');
+appendFolders(target, [
+  { path: 'C:/new', webkitRelativePath: 'new/file.txt' },
+  { path: 'C:/existing', webkitRelativePath: 'existing/other.txt' }
+]);
+assert.strictEqual(target.value, 'C:/existing\nC:/new');
+
+console.log('appendFolders tests passed');


### PR DESCRIPTION
## Summary
- Default to `<input type="file" webkitdirectory>` for folder selection, supporting multi-folder selection in one dialog
- Fall back to `showDirectoryPicker()` when the input approach isn't supported, maintaining cancel safety

## Testing
- `node tests/client/appendFolders.test.js`
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a54d00c930832689f9c7261284590a