### PR TITLE
Enable drag-and-drop folder input

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The published files are in `src/MklinkUi.WebUI/bin/Release/net8.0/publish`.
 The dark-themed web interface centers its main card on screen for common desktop resolutions. Two link modes are available:
 
 - **File → File** – select a single source file and a destination folder. A link with the same file name is created inside the destination folder.
- - **Folder → Folder** – select one or more source folders and a destination folder. The picker allows multi-selection; cancelling it simply closes the dialog. Each selected folder is linked into the destination folder using its original name.
+- **Folder → Folder** – select one or more source folders and a destination folder. The picker allows multi-selection, and the source field accepts drag-and-drop of folders; cancelling it simply closes the dialog. Each selected folder is linked into the destination folder using its original name.
 
 All paths must be provided as absolute paths; relative paths are rejected by the UI and services.
 

--- a/src/MklinkUi.WebUI/Pages/Index.cshtml
+++ b/src/MklinkUi.WebUI/Pages/Index.cshtml
@@ -63,11 +63,11 @@
                 <div class="mb-3" id="folderSource">
                     <label class="form-label" asp-for="SourceFolders">Select one or more source folders</label>
                     <div class="input-group">
-                        <textarea class="form-control" id="sourceFolders" asp-for="SourceFolders" rows="5" placeholder="C:\source\folder"></textarea>
+                        <textarea class="form-control" id="sourceFolders" asp-for="SourceFolders" rows="5" placeholder="C:\source\folder" ondragover="event.preventDefault()" ondrop="dropFolders(event)" ondragenter="this.classList.add('dragover')" ondragleave="this.classList.remove('dragover')"></textarea>
                         <button type="button" class="btn btn-outline-secondary" onclick="browseFolder('sourceFolders', true)"><i class="fa-solid fa-folder-open me-1"></i>Browse Folders…</button>
                     </div>
                     <span asp-validation-for="SourceFolders" class="text-danger"></span>
-                    <div class="form-text">Enter one absolute folder path per line or use Browse to select multiple folders.</div>
+                    <div class="form-text">Enter one absolute folder path per line, drag and drop folders, or use Browse to select multiple folders.</div>
                 </div>
 
                 <div class="mb-3" id="folderDest">

--- a/src/MklinkUi.WebUI/wwwroot/css/site.css
+++ b/src/MklinkUi.WebUI/wwwroot/css/site.css
@@ -42,3 +42,7 @@ main {
 .validation-summary-valid {
   display: none;
 }
+
+#sourceFolders.dragover {
+  border: 2px dashed #258cfb;
+}

--- a/src/MklinkUi.WebUI/wwwroot/js/site.js
+++ b/src/MklinkUi.WebUI/wwwroot/js/site.js
@@ -80,8 +80,17 @@ function appendFolders(target, files) {
     });
 }
 
+function dropFolders(evt) {
+    evt.preventDefault();
+    const target = document.getElementById('sourceFolders');
+    if (target) {
+        target.classList.remove('dragover');
+        appendFolders(target, evt.dataTransfer.files);
+    }
+}
+
 if (typeof module !== 'undefined') {
-    module.exports = { appendFolders };
+    module.exports = { appendFolders, dropFolders };
 }
 
 function toggleInputs() {

--- a/tests/client/dropFolders.test.js
+++ b/tests/client/dropFolders.test.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+const { dropFolders } = require('../../src/MklinkUi.WebUI/wwwroot/js/site.js');
+
+let prevented = false;
+const target = { value: '', classList: { remove: () => {} } };
+
+global.document = { getElementById: () => target };
+
+dropFolders({ preventDefault: () => { prevented = true; }, dataTransfer: { files: [{ path: 'C:/new' }] } });
+
+assert.strictEqual(target.value, 'C:/new');
+assert.strictEqual(prevented, true);
+
+console.log('dropFolders test passed');


### PR DESCRIPTION
## Summary
- support dropping multiple folders onto the source field
- highlight the drop target and document drag-and-drop usage
- test dropFolders handler

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`
- `node tests/client/appendFolders.test.js`
- `node tests/client/dropFolders.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a5693631848326b76626ce74148f5c