### PR TITLE
Fix directory drops not populating source field

### DIFF
--- a/src/MklinkUi.WebUI/wwwroot/js/site.js
+++ b/src/MklinkUi.WebUI/wwwroot/js/site.js
@@ -83,10 +83,24 @@ function appendFolders(target, files) {
 function dropFolders(evt) {
     evt.preventDefault();
     const target = document.getElementById('sourceFolders');
-    if (target) {
-        target.classList.remove('dragover');
-        appendFolders(target, evt.dataTransfer.files);
+    if (!target) {
+        return;
     }
+
+    target.classList.remove('dragover');
+
+    let files = evt.dataTransfer.files;
+
+    // Some browsers provide directories via dataTransfer.items rather than files.
+    if ((!files || files.length === 0) && evt.dataTransfer.items) {
+        const items = Array.from(evt.dataTransfer.items);
+        files = items
+            .map(i => i.webkitGetAsEntry && i.webkitGetAsEntry())
+            .filter(e => e && e.isDirectory)
+            .map(e => ({ path: e.fullPath.replace(/^\//, '') }));
+    }
+
+    appendFolders(target, files);
 }
 
 if (typeof module !== 'undefined') {

--- a/tests/client/dropFolders.test.js
+++ b/tests/client/dropFolders.test.js
@@ -6,9 +6,22 @@ const target = { value: '', classList: { remove: () => {} } };
 
 global.document = { getElementById: () => target };
 
+// Existing FileList support
 dropFolders({ preventDefault: () => { prevented = true; }, dataTransfer: { files: [{ path: 'C:/new' }] } });
-
 assert.strictEqual(target.value, 'C:/new');
+assert.strictEqual(prevented, true);
+
+// Reset for DataTransferItemList scenario
+prevented = false;
+target.value = '';
+
+const items = [{
+    webkitGetAsEntry: () => ({ isDirectory: true, fullPath: '/C/dir' })
+}];
+
+dropFolders({ preventDefault: () => { prevented = true; }, dataTransfer: { files: [], items } });
+
+assert.strictEqual(target.value, 'C/dir');
 assert.strictEqual(prevented, true);
 
 console.log('dropFolders test passed');


### PR DESCRIPTION
## Summary
- handle DataTransfer items in `dropFolders` so dropped directories populate the textarea
- test dropFolders with both FileList and DataTransferItemList inputs

## Testing
- `node tests/client/appendFolders.test.js && node tests/client/dropFolders.test.js`
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a58a3a233083269c8de1839e135f32