### PR TITLE
fix: load jQuery validation from CDN

### DIFF
--- a/src/MklinkUi.WebUI/Pages/Shared/_ValidationScriptsPartial.cshtml
+++ b/src/MklinkUi.WebUI/Pages/Shared/_ValidationScriptsPartial.cshtml
@@ -1,2 +1,2 @@
-﻿<script src="~/lib/jquery-validation/dist/jquery.validate.min.js"></script>
-<script src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.19.5/jquery.validate.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validation-unobtrusive/3.2.12/jquery.validate.unobtrusive.min.js"></script>


### PR DESCRIPTION
## Summary
- load jQuery validation and unobtrusive scripts from CDN instead of missing local paths

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a58ccfcc748326afc92f7ac778296e