### PR TITLE
Prefer directory items for drag-and-drop paths

### DIFF
--- a/src/MklinkUi.WebUI/wwwroot/js/site.js
+++ b/src/MklinkUi.WebUI/wwwroot/js/site.js
@@ -89,10 +89,9 @@ async function dropFolders(evt) {
 
     target.classList.remove('dragover');
 
-    let files = evt.dataTransfer.files;
+    let files = [];
 
-    // Some browsers provide directories via dataTransfer.items rather than files.
-    if ((!files || files.length === 0) && evt.dataTransfer.items) {
+    if (evt.dataTransfer.items) {
         const items = Array.from(evt.dataTransfer.items);
         const handles = await Promise.all(items.map(async i => {
             if (i.getAsFileSystemHandle) {
@@ -113,6 +112,10 @@ async function dropFolders(evt) {
             return null;
         }));
         files = handles.filter(Boolean);
+    }
+
+    if (files.length === 0 && evt.dataTransfer.files) {
+        files = evt.dataTransfer.files;
     }
 
     appendFolders(target, files);

--- a/tests/client/dropFolders.test.js
+++ b/tests/client/dropFolders.test.js
@@ -38,6 +38,23 @@ global.document = { getElementById: () => target };
     assert.strictEqual(target.value, 'C:/handleDir');
     assert.strictEqual(prevented, true);
 
+    // Prefer items when File objects lack path data
+    prevented = false;
+    target.value = '';
+
+    const fileItems = [{ name: 'file.txt', webkitRelativePath: '' }];
+    const itemWithHandle = [{
+        getAsFileSystemHandle: async () => ({ kind: 'directory', name: 'D', path: 'D:/fromItems' })
+    }];
+
+    await dropFolders({
+        preventDefault: () => { prevented = true; },
+        dataTransfer: { files: fileItems, items: itemWithHandle }
+    });
+
+    assert.strictEqual(target.value, 'D:/fromItems');
+    assert.strictEqual(prevented, true);
+
     console.log('dropFolders test passed');
 })().catch(err => {
     console.error(err);


### PR DESCRIPTION
## Summary
- Test dropping directories when File objects lack path information
- Prefer `dataTransfer.items` over `files` in drop handler so directories populate the textarea

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test`
- `node tests/client/dropFolders.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a5d57836fc832692a7618c6041d4ac