### PR TITLE
Capture full folder path for multi-selection

### DIFF
--- a/src/MklinkUi.WebUI/wwwroot/js/site.js
+++ b/src/MklinkUi.WebUI/wwwroot/js/site.js
@@ -138,6 +138,9 @@ async function dropFolders(evt) {
                 return null;
             }));
             files = handles.filter(Boolean);
+            if (files.length > 0 && files.every(f => !/[\\/]/.test(f.path))) {
+                files = [];
+            }
         }
     }
 

--- a/src/MklinkUi.WebUI/wwwroot/js/site.js
+++ b/src/MklinkUi.WebUI/wwwroot/js/site.js
@@ -114,7 +114,7 @@ async function dropFolders(evt) {
 
     const dt = evt.dataTransfer || {};
     const uriList = dt.getData?.('text/uri-list') || '';
-    const plain = dt.getData?.('text') || '';
+    const plain = dt.getData?.('text/plain') || dt.getData?.('text') || '';
     const combined = [uriList, plain].filter(Boolean).join('\\n');
     const dtFiles = dt.files;
     const items = dt.items ? Array.from(dt.items) : [];
@@ -145,7 +145,9 @@ async function dropFolders(evt) {
             }));
             files = handles.filter(Boolean);
             if (files.length > 0 && files.every(f => !/[\\/]/.test(f.path))) {
-                files = [];
+                if (combined) {
+                    files = [];
+                }
             }
         }
     }

--- a/src/MklinkUi.WebUI/wwwroot/js/site.js
+++ b/src/MklinkUi.WebUI/wwwroot/js/site.js
@@ -18,6 +18,26 @@ async function browseFile(inputId) {
     input.click();
 }
 
+function getFolderPath(file) {
+    if (!file) return '';
+
+    if (file.path && file.webkitRelativePath) {
+        const base = file.path.slice(0, file.path.length - file.webkitRelativePath.length);
+        const topLevel = file.webkitRelativePath.split(/[/\\]/)[0];
+        return (base + topLevel).replaceAll('\\', '/');
+    }
+
+    if (file.path) {
+        return file.path.replaceAll('\\', '/');
+    }
+
+    if (file.webkitRelativePath) {
+        return file.webkitRelativePath.split(/[/\\]/)[0].replaceAll('\\', '/');
+    }
+
+    return '';
+}
+
 async function browseFolder(inputId, allowMultiple = false) {
     const target = document.getElementById(inputId);
 
@@ -57,9 +77,8 @@ async function browseFolder(inputId, allowMultiple = false) {
     input.onchange = e => {
         const file = e.target.files[0];
         if (file) {
-            // Prefer the full path when available (e.g., Electron or Chromium-based browsers)
-            const path = file.path || file.webkitRelativePath.split('/')[0];
-            target.value = path;
+            const path = getFolderPath(file);
+            if (path) target.value = path;
         }
     };
     input.click();
@@ -68,8 +87,8 @@ async function browseFolder(inputId, allowMultiple = false) {
 function appendFolders(target, files) {
     const dirs = new Set();
     Array.from(files).forEach(f => {
-        const path = (f.path || f.webkitRelativePath.split('/')[0]).replaceAll('\\', '/');
-        dirs.add(path);
+        const path = getFolderPath(f);
+        if (path) dirs.add(path);
     });
     if (dirs.size === 0) return;
     const existing = new Set(target.value.split(/\r?\n/).filter(Boolean));

--- a/src/MklinkUi.WebUI/wwwroot/js/site.js
+++ b/src/MklinkUi.WebUI/wwwroot/js/site.js
@@ -145,6 +145,24 @@ async function dropFolders(evt) {
         files = evt.dataTransfer.files;
     }
 
+    if (files.length === 0 || Array.from(files).every(f => !f.path && !f.webkitRelativePath)) {
+        const uriList = evt.dataTransfer.getData('text/uri-list');
+        const plain = evt.dataTransfer.getData('text');
+        const combined = [uriList, plain].filter(Boolean).join('\n');
+        if (combined) {
+            files = combined.split(/\r?\n/)
+                .map(l => l.trim())
+                .filter(Boolean)
+                .map(p => {
+                    let decoded = p.startsWith('file://') ? decodeURIComponent(p.replace('file://', '')) : p;
+                    if (/^\/[A-Za-z]:/.test(decoded)) {
+                        decoded = decoded.slice(1);
+                    }
+                    return { path: decoded };
+                });
+        }
+    }
+
     appendFolders(target, files);
 }
 

--- a/tests/client/appendFolders.test.js
+++ b/tests/client/appendFolders.test.js
@@ -5,4 +5,12 @@ const target = { value: 'C:/existing' };
 appendFolders(target, []);
 assert.strictEqual(target.value, 'C:/existing');
 
-console.log('appendFolders cancel test passed');
+const targetWithPath = { value: '' };
+const files = [{
+    path: 'C:/base/folder/sub/file.txt',
+    webkitRelativePath: 'folder/sub/file.txt'
+}];
+appendFolders(targetWithPath, files);
+assert.strictEqual(targetWithPath.value, 'C:/base/folder');
+
+console.log('appendFolders tests passed');

--- a/tests/client/appendFolders.test.js
+++ b/tests/client/appendFolders.test.js
@@ -13,4 +13,8 @@ const files = [{
 appendFolders(targetWithPath, files);
 assert.strictEqual(targetWithPath.value, 'C:/base/folder');
 
+const onlyPathTarget = { value: '' };
+appendFolders(onlyPathTarget, [{ path: 'C:/single/folder/file.txt', name: 'file.txt' }]);
+assert.strictEqual(onlyPathTarget.value, 'C:/single/folder');
+
 console.log('appendFolders tests passed');

--- a/tests/client/dropFolders.test.js
+++ b/tests/client/dropFolders.test.js
@@ -51,6 +51,26 @@ global.document = { getElementById: () => target };
     assert.strictEqual(target.value, 'C:/handleDir');
     assert.strictEqual(prevented, true);
 
+    // Fallback to text when handle lacks full path
+    prevented = false;
+    target.value = '';
+
+    const nameOnlyHandle = [{
+        getAsFileSystemHandle: async () => ({ kind: 'directory', name: 'justName' })
+    }];
+
+    await dropFolders({
+        preventDefault: () => { prevented = true; },
+        dataTransfer: {
+            files: [],
+            items: nameOnlyHandle,
+            getData: type => type === 'text' ? 'file:///F:/fullPath' : ''
+        }
+    });
+
+    assert.strictEqual(target.value, 'F:/fullPath');
+    assert.strictEqual(prevented, true);
+
     // Prefer items when File objects lack path data
     prevented = false;
     target.value = '';

--- a/tests/client/dropFolders.test.js
+++ b/tests/client/dropFolders.test.js
@@ -68,6 +68,21 @@ global.document = { getElementById: () => target };
     assert.strictEqual(target.value, 'D:/fromItems');
     assert.strictEqual(prevented, true);
 
+    // Fallback to text data when no file metadata
+    prevented = false;
+    target.value = '';
+
+    await dropFolders({
+        preventDefault: () => { prevented = true; },
+        dataTransfer: {
+            files: [],
+            getData: type => type === 'text' ? 'file:///E:/fromText' : ''
+        }
+    });
+
+    assert.strictEqual(target.value, 'E:/fromText');
+    assert.strictEqual(prevented, true);
+
     console.log('dropFolders test passed');
 })().catch(err => {
     console.error(err);

--- a/tests/client/dropFolders.test.js
+++ b/tests/client/dropFolders.test.js
@@ -64,11 +64,27 @@ global.document = { getElementById: () => target };
         dataTransfer: {
             files: [],
             items: nameOnlyHandle,
-            getData: type => type === 'text' ? 'file:///F:/fullPath' : ''
+            getData: type => type === 'text/plain' ? 'file:///F:/fullPath' : ''
         }
     });
 
     assert.strictEqual(target.value, 'F:/fullPath');
+    assert.strictEqual(prevented, true);
+
+    // Fallback to name when no text data
+    prevented = false;
+    target.value = '';
+
+    await dropFolders({
+        preventDefault: () => { prevented = true; },
+        dataTransfer: {
+            files: [],
+            items: nameOnlyHandle,
+            getData: () => ''
+        }
+    });
+
+    assert.strictEqual(target.value, 'justName');
     assert.strictEqual(prevented, true);
 
     // Prefer items when File objects lack path data

--- a/tests/client/dropFolders.test.js
+++ b/tests/client/dropFolders.test.js
@@ -12,6 +12,19 @@ global.document = { getElementById: () => target };
     assert.strictEqual(target.value, 'C:/new');
     assert.strictEqual(prevented, true);
 
+    // Reset for DataTransferItem getAsFile scenario
+    prevented = false;
+    target.value = '';
+
+    const itemsWithFile = [{
+        getAsFile: () => ({ path: 'C:/fromItem/f.txt', name: 'f.txt' })
+    }];
+
+    await dropFolders({ preventDefault: () => { prevented = true; }, dataTransfer: { files: [], items: itemsWithFile } });
+
+    assert.strictEqual(target.value, 'C:/fromItem');
+    assert.strictEqual(prevented, true);
+
     // Reset for DataTransferItemList scenario
     prevented = false;
     target.value = '';

--- a/tests/client/dropFolders.test.js
+++ b/tests/client/dropFolders.test.js
@@ -103,6 +103,26 @@ global.document = { getElementById: () => target };
     assert.strictEqual(target.value, 'E:/fromText');
     assert.strictEqual(prevented, true);
 
+    // Ensure text is captured before async handle access clears it
+    prevented = false;
+    target.value = '';
+    let textVal = 'file:///G:/delayed';
+    const clearingHandle = [{
+        getAsFileSystemHandle: async () => { textVal = ''; return { kind: 'directory', name: 'noPath' }; }
+    }];
+
+    await dropFolders({
+        preventDefault: () => { prevented = true; },
+        dataTransfer: {
+            files: [],
+            items: clearingHandle,
+            getData: type => type === 'text' ? textVal : ''
+        }
+    });
+
+    assert.strictEqual(target.value, 'G:/delayed');
+    assert.strictEqual(prevented, true);
+
     console.log('dropFolders test passed');
 })().catch(err => {
     console.error(err);


### PR DESCRIPTION
## Summary
- ensure folder picker computes full directory path via new `getFolderPath`
- append and browse functions now record complete folder paths
- extend client tests for appendFolders path handling

## Testing
- `dotnet restore`
- `dotnet build src/MklinkUi.Fakes`
- `dotnet build src/MklinkUi.WebUI`
- `dotnet test --no-build`
- `node tests/client/appendFolders.test.js`
- `node tests/client/dropFolders.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a94d6e7cec83268298e12870052631